### PR TITLE
Hardening v3: Fix panics, log silent errors, migrate debug prints to slog

### DIFF
--- a/cmd/astonish/channels.go
+++ b/cmd/astonish/channels.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -229,7 +230,10 @@ func handleTelegramSetup() error {
 
 	// Save bot token to encrypted credential store (keep config.yaml clean)
 	cfg.Channels.Telegram.BotToken = botToken // fallback: stays in config if store fails
-	configDir, _ := config.GetConfigDir()
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		slog.Warn("failed to get config directory", "error", err)
+	}
 	if configDir != "" {
 		if store, storeErr := credentials.Open(configDir); storeErr == nil {
 			if setErr := store.SetSecret("channels.telegram.bot_token", botToken); setErr == nil {

--- a/cmd/astonish/channels.go
+++ b/cmd/astonish/channels.go
@@ -670,7 +670,10 @@ func notifyDaemonChannelsChanged(appCfg *config.AppConfig) {
 			return
 		}
 		// Read error body for diagnostics
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		if len(body) > 0 {
 			var errResp map[string]string
 			if json.Unmarshal(body, &errResp) == nil {

--- a/cmd/astonish/daemon.go
+++ b/cmd/astonish/daemon.go
@@ -3,6 +3,7 @@ package astonish
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/schardosin/astonish/pkg/config"
@@ -56,7 +57,10 @@ func handleDaemonInstall(args []string) error {
 	}
 
 	// Load config for defaults
-	appCfg, _ := config.LoadAppConfig()
+	appCfg, err := config.LoadAppConfig()
+	if err != nil {
+		slog.Warn("failed to load app config", "error", err)
+	}
 	installPort := *port
 	if installPort <= 0 && appCfg != nil {
 		installPort = appCfg.Daemon.GetPort()

--- a/cmd/astonish/daemon.go
+++ b/cmd/astonish/daemon.go
@@ -92,7 +92,10 @@ func handleDaemonInstall(args []string) error {
 	fleetsDir, flErr := config.GetFleetsDir()
 	if flErr == nil {
 		// Ensure bundled fleets are on disk before loading
-		_, _ = fleet.EnsureBundled(fleetsDir)
+		_, bundleErr := fleet.EnsureBundled(fleetsDir)
+		if bundleErr != nil {
+			slog.Warn("failed to ensure bundled fleets", "error", bundleErr)
+		}
 		if fleets, loadErr := fleet.LoadFleets(fleetsDir); loadErr == nil {
 			for _, name := range fleet.CollectDelegateEnvVars(fleets) {
 				if val := os.Getenv(name); val != "" {

--- a/cmd/astonish/drill.go
+++ b/cmd/astonish/drill.go
@@ -932,7 +932,10 @@ func handleDrillRemoveCommand(args []string) error {
 
 func handleRemoveSuite(dirs []string, suite *adrill.LoadedSuite, deleteTests bool, force bool) error {
 	// Find all associated tests
-	tests, _ := adrill.FindTestsForSuite(dirs, suite.Name)
+	tests, findErr := adrill.FindTestsForSuite(dirs, suite.Name)
+	if findErr != nil {
+		slog.Warn("failed to find tests for suite", "suite", suite.Name, "error", findErr)
+	}
 
 	// Show what will be deleted
 	fmt.Printf("Suite: %s (%s)\n", suite.Name, suite.File)
@@ -1053,7 +1056,10 @@ func handleRemoveTest(dirs []string, test *adrill.LoadedTest, suite *adrill.Load
 	}
 
 	// Warn about remaining tests in suite
-	remaining, _ := adrill.FindTestsForSuite(dirs, suite.Name)
+	remaining, findErr := adrill.FindTestsForSuite(dirs, suite.Name)
+	if findErr != nil {
+		slog.Warn("failed to find remaining tests for suite", "suite", suite.Name, "error", findErr)
+	}
 	fmt.Printf("\nRemoved test %q. Suite %q has %d remaining test(s).\n", test.Name, suite.Name, len(remaining))
 	return nil
 }

--- a/cmd/astonish/fleet.go
+++ b/cmd/astonish/fleet.go
@@ -208,7 +208,10 @@ func handleFleetShow(keyOrPrefix string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return fmt.Errorf("daemon returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
@@ -362,7 +365,10 @@ func handleFleetActivate(keyOrPrefix string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return fmt.Errorf("activation failed: %s", strings.TrimSpace(string(body)))
 	}
 
@@ -386,7 +392,10 @@ func handleFleetDeactivate(keyOrPrefix string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return fmt.Errorf("deactivation failed: %s", strings.TrimSpace(string(body)))
 	}
 
@@ -413,7 +422,10 @@ func handleFleetStatus(keyOrPrefix string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return fmt.Errorf("failed to get status: %s", strings.TrimSpace(string(body)))
 	}
 
@@ -485,7 +497,10 @@ func handleFleetDelete(keyOrPrefix string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return fmt.Errorf("deletion failed: %s", strings.TrimSpace(string(body)))
 	}
 
@@ -547,7 +562,10 @@ func fetchFleetPlans() ([]fleetPlanListItemAPI, error) {
 		return nil, fmt.Errorf("daemon returned HTTP %d", resp.StatusCode)
 	}
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
 
 	var result struct {
 		Plans []fleetPlanListItemAPI `json:"plans"`

--- a/cmd/astonish/fleet.go
+++ b/cmd/astonish/fleet.go
@@ -474,7 +474,10 @@ func handleFleetDelete(keyOrPrefix string) error {
 	}
 
 	baseURL := getDaemonBaseURL()
-	req, _ := http.NewRequest(http.MethodDelete, baseURL+"/api/fleet-plans/"+plan.Key, nil)
+	req, err := http.NewRequest(http.MethodDelete, baseURL+"/api/fleet-plans/"+plan.Key, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to contact daemon: %w", err)

--- a/cmd/astonish/memory.go
+++ b/cmd/astonish/memory.go
@@ -246,8 +246,14 @@ func handleMemoryListCommand(args []string) error {
 			return filepath.SkipDir
 		}
 		if !d.IsDir() && strings.HasSuffix(d.Name(), ".md") {
-			info, _ := d.Info()
-			relPath, _ := filepath.Rel(memDir, path)
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				slog.Warn("failed to get file info", "path", path, "error", infoErr)
+			}
+			relPath, relErr := filepath.Rel(memDir, path)
+			if relErr != nil {
+				slog.Warn("failed to compute relative path", "path", path, "error", relErr)
+			}
 			size := int64(0)
 			if info != nil {
 				size = info.Size()

--- a/cmd/astonish/memory.go
+++ b/cmd/astonish/memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -300,9 +301,18 @@ func handleMemoryStatusCommand(args []string) error {
 	fmt.Println()
 
 	// Directories
-	memDir, _ := config.GetMemoryDir(memCfg)
-	vecDir, _ := config.GetVectorDir(memCfg)
-	modelsDir, _ := config.GetModelsDir()
+	memDir, err := config.GetMemoryDir(memCfg)
+	if err != nil {
+		slog.Warn("failed to get memory directory", "error", err)
+	}
+	vecDir, err := config.GetVectorDir(memCfg)
+	if err != nil {
+		slog.Warn("failed to get vector directory", "error", err)
+	}
+	modelsDir, err := config.GetModelsDir()
+	if err != nil {
+		slog.Warn("failed to get models directory", "error", err)
+	}
 
 	fmt.Printf("  Memory dir:   %s\n", memDir)
 	fmt.Printf("  Vector dir:   %s\n", vecDir)

--- a/cmd/astonish/scheduler.go
+++ b/cmd/astonish/scheduler.go
@@ -148,7 +148,10 @@ func handleSchedulerToggle(idOrName string, enable bool) error {
 	data, _ := json.Marshal(job)
 
 	baseURL := getDaemonBaseURL()
-	req, _ := http.NewRequest(http.MethodPut, baseURL+"/api/scheduler/jobs/"+job.ID, strings.NewReader(string(data)))
+	req, err := http.NewRequest(http.MethodPut, baseURL+"/api/scheduler/jobs/"+job.ID, strings.NewReader(string(data)))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -175,7 +178,10 @@ func handleSchedulerRemove(idOrName string) error {
 	}
 
 	baseURL := getDaemonBaseURL()
-	req, _ := http.NewRequest(http.MethodDelete, baseURL+"/api/scheduler/jobs/"+job.ID, nil)
+	req, err := http.NewRequest(http.MethodDelete, baseURL+"/api/scheduler/jobs/"+job.ID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to contact daemon: %w", err)

--- a/cmd/astonish/scheduler.go
+++ b/cmd/astonish/scheduler.go
@@ -145,7 +145,10 @@ func handleSchedulerToggle(idOrName string, enable bool) error {
 	}
 
 	job.Enabled = enable
-	data, _ := json.Marshal(job)
+	data, marshalErr := json.Marshal(job)
+	if marshalErr != nil {
+		return fmt.Errorf("failed to marshal job: %w", marshalErr)
+	}
 
 	baseURL := getDaemonBaseURL()
 	req, err := http.NewRequest(http.MethodPut, baseURL+"/api/scheduler/jobs/"+job.ID, strings.NewReader(string(data)))
@@ -270,7 +273,10 @@ func fetchSchedulerJobs() ([]schedulerJobAPI, error) {
 		return nil, fmt.Errorf("daemon returned HTTP %d — check that the daemon is running and accessible", resp.StatusCode)
 	}
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
 
 	var result struct {
 		Jobs []schedulerJobAPI `json:"jobs"`

--- a/cmd/astonish/setup.go
+++ b/cmd/astonish/setup.go
@@ -1198,7 +1198,10 @@ func handleWebToolSetup() error {
 
 	// Save API key to credential store
 	storeKeyInConfig := true // fallback to config if store fails
-	configDir, _ := config.GetConfigDir()
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		slog.Warn("failed to get config directory", "error", err)
+	}
 	if configDir != "" {
 		if store, storeErr := credentials.Open(configDir); storeErr == nil {
 			for _, ev := range srv.EnvVars {

--- a/cmd/astonish/skills.go
+++ b/cmd/astonish/skills.go
@@ -2,6 +2,7 @@ package astonish
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -49,7 +50,10 @@ func handleSkillsCommand(args []string) error {
 }
 
 func loadAllSkills() ([]skills.Skill, error) {
-	appCfg, _ := config.LoadAppConfig()
+	appCfg, err := config.LoadAppConfig()
+	if err != nil {
+		slog.Warn("failed to load app config", "error", err)
+	}
 	var skillsCfg config.SkillsConfig
 	if appCfg != nil {
 		skillsCfg = appCfg.Skills
@@ -153,7 +157,10 @@ func handleSkillsCheck() error {
 }
 
 func handleSkillsCreate(name string) error {
-	appCfg, _ := config.LoadAppConfig()
+	appCfg, err := config.LoadAppConfig()
+	if err != nil {
+		slog.Warn("failed to load app config", "error", err)
+	}
 	var skillsCfg config.SkillsConfig
 	if appCfg != nil {
 		skillsCfg = appCfg.Skills
@@ -213,7 +220,10 @@ func handleSkillsInstall(input string) error {
 		return fmt.Errorf("invalid input: %w", err)
 	}
 
-	appCfg, _ := config.LoadAppConfig()
+	appCfg, err := config.LoadAppConfig()
+	if err != nil {
+		slog.Warn("failed to load app config", "error", err)
+	}
 	var skillsCfg config.SkillsConfig
 	if appCfg != nil {
 		skillsCfg = appCfg.Skills

--- a/cmd/astonish/skills.go
+++ b/cmd/astonish/skills.go
@@ -59,7 +59,10 @@ func loadAllSkills() ([]skills.Skill, error) {
 		skillsCfg = appCfg.Skills
 	}
 
-	workDir, _ := os.Getwd()
+	workDir, wdErr := os.Getwd()
+	if wdErr != nil {
+		slog.Warn("failed to get working directory", "error", wdErr)
+	}
 	return skills.LoadSkills(
 		skillsCfg.GetUserSkillsDir(),
 		skillsCfg.ExtraDirs,

--- a/cmd/astonish/studio.go
+++ b/cmd/astonish/studio.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 
 	"github.com/schardosin/astonish/pkg/api"
 	"github.com/schardosin/astonish/pkg/config"
@@ -22,7 +23,10 @@ func handleStudioCommand(args []string) error {
 
 	// Set up provider environment variables from config
 	// Prefer credential store for secrets, fall back to legacy config
-	appCfg, _ := config.LoadAppConfig()
+	appCfg, err := config.LoadAppConfig()
+	if err != nil {
+		slog.Warn("failed to load app config", "error", err)
+	}
 	if appCfg != nil {
 		if cfgDir, err := config.GetConfigDir(); err == nil {
 			if cs, csErr := credentials.Open(cfgDir); csErr == nil {

--- a/cmd/astonish/tools.go
+++ b/cmd/astonish/tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"sort"
 	"strings"
@@ -199,7 +200,10 @@ func handleToolsEnableCommand(args []string) error {
 	if err := config.SetMCPServerEnabled(serverName, true); err != nil {
 		// If server not found, show available servers
 		if strings.Contains(err.Error(), "not found") {
-			names, _ := config.GetMCPServerNames()
+			names, namesErr := config.GetMCPServerNames()
+			if namesErr != nil {
+				slog.Warn("failed to get MCP server names", "error", namesErr)
+			}
 			if len(names) > 0 {
 				return fmt.Errorf("%w\nAvailable servers: %s", err, strings.Join(names, ", "))
 			}
@@ -226,7 +230,10 @@ func handleToolsDisableCommand(args []string) error {
 	if err := config.SetMCPServerEnabled(serverName, false); err != nil {
 		// If server not found, show available servers
 		if strings.Contains(err.Error(), "not found") {
-			names, _ := config.GetMCPServerNames()
+			names, namesErr := config.GetMCPServerNames()
+			if namesErr != nil {
+				slog.Warn("failed to get MCP server names", "error", namesErr)
+			}
 			if len(names) > 0 {
 				return fmt.Errorf("%w\nAvailable servers: %s", err, strings.Join(names, ", "))
 			}

--- a/pkg/agent/error_recovery.go
+++ b/pkg/agent/error_recovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"google.golang.org/adk/model"
@@ -54,10 +55,9 @@ func (e *ErrorRecoveryNode) Decide(ctx context.Context, errCtx ErrorContext) (*R
 	userPrompt := e.buildUserPrompt(errCtx)
 
 	if e.DebugMode {
-		fmt.Printf("\n[ERROR RECOVERY] Analyzing error...\n")
-		fmt.Printf("[ERROR RECOVERY] Node: %s (type: %s)\n", errCtx.NodeName, errCtx.NodeType)
-		fmt.Printf("[ERROR RECOVERY] Attempt: %d/%d\n", errCtx.AttemptCount, errCtx.MaxRetries)
-		fmt.Printf("[ERROR RECOVERY] Error: %s\n", errCtx.ErrorMessage)
+		slog.Debug("error recovery analyzing error",
+			"component", "error-recovery", "node", errCtx.NodeName, "nodeType", errCtx.NodeType,
+			"attempt", errCtx.AttemptCount, "maxRetries", errCtx.MaxRetries, "error", errCtx.ErrorMessage)
 	}
 
 	// Create request - combine system prompt and user prompt
@@ -76,9 +76,7 @@ func (e *ErrorRecoveryNode) Decide(ctx context.Context, errCtx ErrorContext) (*R
 	var responseText string
 	for resp, err := range e.LLM.GenerateContent(ctx, req, false) {
 		if err != nil {
-			if e.DebugMode {
-				fmt.Printf("[ERROR RECOVERY] LLM call failed: %v\n", err)
-			}
+			slog.Debug("error recovery LLM call failed", "component", "error-recovery", "error", err)
 			// Fallback to simple heuristic
 			return e.fallbackDecision(errCtx), nil
 		}
@@ -90,24 +88,22 @@ func (e *ErrorRecoveryNode) Decide(ctx context.Context, errCtx ErrorContext) (*R
 	}
 
 	if e.DebugMode {
-		fmt.Printf("[ERROR RECOVERY] LLM Response: %s\n", responseText)
+		slog.Debug("error recovery LLM response", "component", "error-recovery", "response", responseText)
 	}
 
 	// Parse decision
 	decision, err := e.parseDecision(responseText)
 	if err != nil {
-		if e.DebugMode {
-			fmt.Printf("[ERROR RECOVERY] Failed to parse decision: %v\n", err)
-		}
+		slog.Debug("error recovery failed to parse decision", "component", "error-recovery", "error", err)
 		// Fallback to simple heuristic
 		return e.fallbackDecision(errCtx), nil
 	}
 
 	if e.DebugMode {
 		if decision.ShouldRetry {
-			fmt.Printf("[ERROR RECOVERY] Decision: RETRY - %s\n", decision.Reason)
+			slog.Debug("error recovery decision: RETRY", "component", "error-recovery", "reason", decision.Reason)
 		} else {
-			fmt.Printf("[ERROR RECOVERY] Decision: ABORT - %s\n", decision.Reason)
+			slog.Debug("error recovery decision: ABORT", "component", "error-recovery", "reason", decision.Reason)
 		}
 	}
 

--- a/pkg/agent/lazy_mcp_toolset.go
+++ b/pkg/agent/lazy_mcp_toolset.go
@@ -166,7 +166,7 @@ func (l *LazyMCPToolset) ensureServerStarted(ctx context.Context, sessionID stri
 	}
 
 	if l.debugMode {
-		fmt.Printf("[Chat Lazy] Starting MCP server '%s' on demand (host)...\n", l.serverName)
+		slog.Debug("starting MCP server on demand (host)", "component", "lazy-mcp", "server", l.serverName)
 	}
 
 	return l.startOnHost(ctx)
@@ -183,7 +183,7 @@ func (l *LazyMCPToolset) ensureServerStartedSandbox(ctx context.Context, session
 	}
 
 	if l.debugMode {
-		fmt.Printf("[Chat Lazy] Starting MCP server '%s' on demand (sandbox, session=%s)...\n", l.serverName, sessionID)
+		slog.Debug("starting MCP server on demand (sandbox)", "component", "lazy-mcp", "server", l.serverName, "session", sessionID)
 	}
 
 	// Choose: fleet direct client vs pool
@@ -230,7 +230,7 @@ func (l *LazyMCPToolset) startOnHost(ctx context.Context) error {
 	l.started = true
 
 	if l.debugMode {
-		fmt.Printf("[Chat Lazy] MCP server '%s' started (host): %d tools available\n", l.serverName, len(l.liveTools))
+		slog.Debug("MCP server started (host)", "component", "lazy-mcp", "server", l.serverName, "tools", len(l.liveTools))
 	}
 
 	return nil
@@ -270,7 +270,7 @@ func (l *LazyMCPToolset) startInContainerDirect(ctx context.Context, sessionID s
 // Caller must hold l.mu.
 func (l *LazyMCPToolset) startInContainerWith(ctx context.Context, sessionID string, incusClient *sandbox.IncusClient, containerName string) error {
 	if l.debugMode {
-		fmt.Printf("[Chat Lazy] Connecting MCP server '%s' in container %s (session=%s)...\n", l.serverName, containerName, sessionID)
+		slog.Debug("connecting MCP server in container", "component", "lazy-mcp", "server", l.serverName, "container", containerName, "session", sessionID)
 	}
 
 	// Create the container transport
@@ -313,7 +313,7 @@ func (l *LazyMCPToolset) startInContainerWith(ctx context.Context, sessionID str
 	}
 
 	if l.debugMode {
-		fmt.Printf("[Chat Lazy] MCP server '%s' started (container=%s, session=%s): %d tools available\n", l.serverName, containerName, sessionID, len(liveTools))
+		slog.Debug("MCP server started (container)", "component", "lazy-mcp", "server", l.serverName, "container", containerName, "session", sessionID, "tools", len(liveTools))
 	}
 
 	return nil

--- a/pkg/agent/memory_reflection.go
+++ b/pkg/agent/memory_reflection.go
@@ -76,19 +76,15 @@ func (r *MemoryReflector) Reflect(ctx context.Context, trace *ExecutionTrace) {
 	// Check qualification
 	toolCallCount := trace.ToolCallCount()
 	if toolCallCount < minToolCallsForReflection {
-		if r.DebugMode {
-			fmt.Printf("[Memory Reflection] Skipped: only %d tool calls (threshold: %d)\n",
-				toolCallCount, minToolCallsForReflection)
-		}
+		slog.Debug("memory reflection skipped: insufficient tool calls",
+			"component", "memory-reflection", "toolCalls", toolCallCount, "threshold", minToolCallsForReflection)
 		return
 	}
 
 	// Check if memory_save was already called during the turn
 	for _, step := range trace.Steps {
 		if step.ToolName == "memory_save" {
-			if r.DebugMode {
-				fmt.Println("[Memory Reflection] Skipped: memory_save already called during turn")
-			}
+			slog.Debug("memory reflection skipped: memory_save already called during turn", "component", "memory-reflection")
 			return
 		}
 	}
@@ -97,7 +93,7 @@ func (r *MemoryReflector) Reflect(ctx context.Context, trace *ExecutionTrace) {
 	traceSummary := buildTraceSummary(trace)
 
 	if r.DebugMode {
-		fmt.Printf("[Memory Reflection] Running reflection on %d tool calls\n", toolCallCount)
+		slog.Debug("running memory reflection", "component", "memory-reflection", "toolCalls", toolCallCount)
 	}
 
 	// Build the LLM request with memory_save tool
@@ -147,18 +143,14 @@ func (r *MemoryReflector) Reflect(ctx context.Context, trace *ExecutionTrace) {
 	var lastResp *model.LLMResponse
 	for resp, err := range r.LLM.GenerateContent(ctx, req, false) {
 		if err != nil {
-			if r.DebugMode {
-				fmt.Printf("[Memory Reflection] LLM error: %v\n", err)
-			}
+			slog.Debug("memory reflection LLM error", "component", "memory-reflection", "error", err)
 			return
 		}
 		lastResp = resp
 	}
 
 	if lastResp == nil || lastResp.Content == nil {
-		if r.DebugMode {
-			fmt.Println("[Memory Reflection] No response from LLM")
-		}
+		slog.Debug("memory reflection: no response from LLM", "component", "memory-reflection")
 		return
 	}
 
@@ -171,12 +163,10 @@ func (r *MemoryReflector) Reflect(ctx context.Context, trace *ExecutionTrace) {
 		}
 	}
 
-	if r.DebugMode {
-		if saveCount > 0 {
-			fmt.Printf("[Memory Reflection] Saved %d knowledge entries\n", saveCount)
-		} else {
-			fmt.Println("[Memory Reflection] Model decided nothing worth saving")
-		}
+	if saveCount > 0 {
+		slog.Debug("memory reflection saved entries", "component", "memory-reflection", "count", saveCount)
+	} else {
+		slog.Debug("memory reflection: model decided nothing worth saving", "component", "memory-reflection")
 	}
 }
 
@@ -193,9 +183,7 @@ func (r *MemoryReflector) executeSave(ctx context.Context, fc *genai.FunctionCal
 	overwrite, _ := args["overwrite"].(bool)
 
 	if category == "" || content == "" {
-		if r.DebugMode {
-			fmt.Println("[Memory Reflection] Skipped save: missing category or content")
-		}
+		slog.Debug("memory reflection skipped save: missing category or content", "component", "memory-reflection")
 		return
 	}
 
@@ -207,14 +195,10 @@ func (r *MemoryReflector) executeSave(ctx context.Context, fc *genai.FunctionCal
 		// Core tier: append to MEMORY.md
 		err := r.MemoryManager.Append(category, content, overwrite)
 		if err != nil {
-			if r.DebugMode {
-				fmt.Printf("[Memory Reflection] Failed to save to MEMORY.md: %v\n", err)
-			}
+			slog.Debug("memory reflection failed to save to MEMORY.md", "component", "memory-reflection", "error", err)
 			return
 		}
-		if r.DebugMode {
-			fmt.Printf("[Memory Reflection] Saved to MEMORY.md under '%s'\n", category)
-		}
+		slog.Debug("memory reflection saved to MEMORY.md", "component", "memory-reflection", "category", category)
 
 		// Trigger reindex for MEMORY.md
 		if r.MemoryStore != nil {
@@ -227,9 +211,7 @@ func (r *MemoryReflector) executeSave(ctx context.Context, fc *genai.FunctionCal
 	} else {
 		// Knowledge tier: write to specific file
 		if r.MemoryStore == nil || r.MemoryStore.Config() == nil {
-			if r.DebugMode {
-				fmt.Println("[Memory Reflection] Skipped knowledge tier save: no store configured")
-			}
+			slog.Debug("memory reflection skipped knowledge tier save: no store configured", "component", "memory-reflection")
 			return
 		}
 
@@ -239,9 +221,7 @@ func (r *MemoryReflector) executeSave(ctx context.Context, fc *genai.FunctionCal
 		// Ensure parent directory exists
 		dir := filepath.Dir(absPath)
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			if r.DebugMode {
-				fmt.Printf("[Memory Reflection] Failed to create directory %s: %v\n", dir, err)
-			}
+			slog.Debug("memory reflection failed to create directory", "component", "memory-reflection", "dir", dir, "error", err)
 			return
 		}
 
@@ -254,32 +234,24 @@ func (r *MemoryReflector) executeSave(ctx context.Context, fc *genai.FunctionCal
 		// Append or overwrite
 		if overwrite {
 			if err := os.WriteFile(absPath, []byte(sb.String()), 0644); err != nil {
-				if r.DebugMode {
-					fmt.Printf("[Memory Reflection] Failed to write %s: %v\n", targetFile, err)
-				}
+				slog.Debug("memory reflection failed to write file", "component", "memory-reflection", "file", targetFile, "error", err)
 				return
 			}
 		} else {
 			f, err := os.OpenFile(absPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				if r.DebugMode {
-					fmt.Printf("[Memory Reflection] Failed to append to %s: %v\n", targetFile, err)
-				}
+				slog.Debug("memory reflection failed to open file for append", "component", "memory-reflection", "file", targetFile, "error", err)
 				return
 			}
 			_, err = f.WriteString(sb.String())
 			f.Close()
 			if err != nil {
-				if r.DebugMode {
-					fmt.Printf("[Memory Reflection] Failed to append to %s: %v\n", targetFile, err)
-				}
+				slog.Debug("memory reflection failed to append to file", "component", "memory-reflection", "file", targetFile, "error", err)
 				return
 			}
 		}
 
-		if r.DebugMode {
-			fmt.Printf("[Memory Reflection] Saved to %s under '%s'\n", targetFile, category)
-		}
+		slog.Debug("memory reflection saved to file", "component", "memory-reflection", "file", targetFile, "category", category)
 
 		// Trigger reindex
 		if r.MemoryStore != nil {

--- a/pkg/api/ai_chat_tools.go
+++ b/pkg/api/ai_chat_tools.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/schardosin/astonish/pkg/mcpstore"
@@ -706,7 +707,10 @@ func getAvailableTools(ctx context.Context) []ToolInfo {
 
 	// Fallback to internal tools only if cache not ready
 	var allTools []ToolInfo
-	internalTools, _ := tools.GetInternalTools()
+	internalTools, intErr := tools.GetInternalTools()
+	if intErr != nil {
+		slog.Warn("failed to get internal tools", "error", intErr)
+	}
 	for _, t := range internalTools {
 		allTools = append(allTools, ToolInfo{
 			Name:        t.Name(),

--- a/pkg/api/fleet_session_handlers.go
+++ b/pkg/api/fleet_session_handlers.go
@@ -165,7 +165,10 @@ func StartFleetSessionFromPlan(planKey, initialMessage string) (*FleetSessionRes
 	// Wire sandbox container for this fleet session (fails if sandbox is enabled but unavailable)
 	ghToken := ""
 	if credStore := getAPICredentialStore(); credStore != nil {
-		resolved, _ := fleet.ResolveCredentials(plan, credStore)
+		resolved, err := fleet.ResolveCredentials(plan, credStore)
+		if err != nil {
+			slog.Warn("failed to resolve fleet credentials", "plan", plan.Key, "error", err)
+		}
 		ghToken = fleet.GitHubToken(resolved)
 	}
 	if err := wireFleetSandbox(fleetSession, plan, ghToken); err != nil {
@@ -1044,7 +1047,10 @@ func buildSandboxEnv(plan *fleet.FleetPlan, ghToken string) map[string]string {
 	// Resolve BIFROST_API_KEY from credential store for delegate subprocess auth
 	credStore := getAPICredentialStore()
 	if credStore != nil && plan != nil {
-		resolved, _ := fleet.ResolveCredentials(plan, credStore)
+		resolved, err := fleet.ResolveCredentials(plan, credStore)
+		if err != nil {
+			slog.Warn("failed to resolve fleet credentials", "plan", plan.Key, "error", err)
+		}
 		// If the plan has a github credential but we didn't get ghToken from
 		// the plan activator, try to resolve it here
 		if ghToken == "" {

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -319,7 +320,10 @@ func SaveAgentHandler(w http.ResponseWriter, r *http.Request) {
 			cachedTools := GetCachedTools()
 
 			// Get MCP store servers (from all taps)
-			storeServers, _ := loadAllServersFromTaps()
+			storeServers, storeErr := loadAllServersFromTaps()
+			if storeErr != nil {
+				slog.Warn("failed to load MCP store servers", "error", storeErr)
+			}
 
 			// Resolve dependencies
 			deps := ResolveMCPDependencies(tools, cachedTools, storeServers, agentConfig.MCPDependencies)

--- a/pkg/api/mcp_dependencies.go
+++ b/pkg/api/mcp_dependencies.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -27,7 +28,7 @@ func ResolveMCPDependencies(toolsSelection []string, cachedTools []ToolInfo, sto
 
 	// Build a map of tool name -> server source
 	toolToServer := make(map[string]string)
-	
+
 	// 1. First populate from system cache (installed tools)
 	for _, tool := range cachedTools {
 		toolToServer[tool.Name] = tool.Source
@@ -43,7 +44,10 @@ func ResolveMCPDependencies(toolsSelection []string, cachedTools []ToolInfo, sto
 	}
 
 	// Load user's MCP config
-	mcpConfig, _ := config.LoadMCPConfig()
+	mcpConfig, err := config.LoadMCPConfig()
+	if err != nil {
+		slog.Warn("failed to load MCP config", "error", err)
+	}
 
 	// Group tools by their server source
 	serverToTools := make(map[string][]string)
@@ -88,7 +92,7 @@ func ResolveMCPDependencies(toolsSelection []string, cachedTools []ToolInfo, sto
 			if serverCfg, found := mcpConfig.MCPServers[serverName]; found {
 				for i := range storeServers {
 					srv := &storeServers[i]
-				if srv.Config != nil && srv.Config.Command != "" && configsMatch(serverCfg, *srv.Config) {
+					if srv.Config != nil && srv.Config.Command != "" && configsMatch(serverCfg, *srv.Config) {
 						matchedServer = srv
 						matchSource = srv.Source
 						break
@@ -140,7 +144,7 @@ func configsMatch(userCfg config.MCPServerConfig, storeCfg mcpstore.ServerConfig
 	if userCfg.Command != storeCfg.Command {
 		return false
 	}
-	
+
 	// Args must match exactly
 	if len(userCfg.Args) != len(storeCfg.Args) {
 		return false
@@ -150,7 +154,7 @@ func configsMatch(userCfg config.MCPServerConfig, storeCfg mcpstore.ServerConfig
 			return false
 		}
 	}
-	
+
 	return true
 }
 
@@ -172,12 +176,12 @@ func CollectToolsFromNodes(nodes []config.Node) []string {
 
 // MCPDependencyStatus represents the status of a single MCP dependency
 type MCPDependencyStatus struct {
-	Server    string                   `json:"server"`
-	Tools     []string                 `json:"tools"`
-	Source    string                   `json:"source"`   // store, tap, inline
-	StoreID   string                   `json:"store_id,omitempty"`
-	Config    *config.MCPServerConfig  `json:"config,omitempty"`
-	Installed bool                     `json:"installed"`
+	Server    string                  `json:"server"`
+	Tools     []string                `json:"tools"`
+	Source    string                  `json:"source"` // store, tap, inline
+	StoreID   string                  `json:"store_id,omitempty"`
+	Config    *config.MCPServerConfig `json:"config,omitempty"`
+	Installed bool                    `json:"installed"`
 }
 
 // CheckMCPDependenciesRequest is the request body for checking dependencies

--- a/pkg/api/mcp_dependencies.go
+++ b/pkg/api/mcp_dependencies.go
@@ -212,7 +212,10 @@ func CheckMCPDependenciesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Load store servers for resolving store_id if missing
-	storeServers, _ := loadAllServersFromTaps()
+	storeServers, storeErr := loadAllServersFromTaps()
+	if storeErr != nil {
+		slog.Warn("failed to load MCP store servers", "error", storeErr)
+	}
 
 	// Check each dependency
 	var statuses []MCPDependencyStatus

--- a/pkg/api/sandbox_handlers.go
+++ b/pkg/api/sandbox_handlers.go
@@ -276,8 +276,14 @@ func SandboxDetailsHandler(w http.ResponseWriter, r *http.Request) {
 			containerName := sandbox.TemplateName(sandbox.BaseTemplate)
 			resp.BaseTemplateExists = client.InstanceExists(containerName)
 
-			tplRegistry, _ := sandbox.NewTemplateRegistry()
-			sessRegistry, _ := sandbox.NewSessionRegistry()
+			tplRegistry, tplErr := sandbox.NewTemplateRegistry()
+			if tplErr != nil {
+				slog.Warn("failed to create template registry", "error", tplErr)
+			}
+			sessRegistry, sessErr := sandbox.NewSessionRegistry()
+			if sessErr != nil {
+				slog.Warn("failed to create session registry", "error", sessErr)
+			}
 			if tplRegistry != nil && sessRegistry != nil {
 				status, statusErr := sandbox.Status(client, tplRegistry, sessRegistry)
 				if statusErr == nil {
@@ -376,7 +382,10 @@ func SandboxContainerListHandler(w http.ResponseWriter, r *http.Request) {
 	for _, e := range entries {
 		registeredNames[e.ContainerName] = true
 	}
-	incusContainers, _ := client.ListSessionContainers()
+	incusContainers, listErr := client.ListSessionContainers()
+	if listErr != nil {
+		slog.Warn("failed to list session containers from Incus", "error", listErr)
+	}
 	var orphans []string
 	for _, inst := range incusContainers {
 		if !registeredNames[inst.Name] {

--- a/pkg/api/sandbox_proxy.go
+++ b/pkg/api/sandbox_proxy.go
@@ -140,7 +140,11 @@ func SandboxProxyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// HTTP reverse proxy
-	target, _ := url.Parse(targetBase)
+	target, err := url.Parse(targetBase)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid proxy target URL: %s", err), http.StatusInternalServerError)
+		return
+	}
 	proxy := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = target.Scheme
@@ -287,7 +291,11 @@ func (m *PortProxyManager) StartProxy(containerName string, containerPort int) (
 			return
 		}
 
-		currentTarget, _ := url.Parse(fmt.Sprintf("http://%s:%d", currentIP, containerPort))
+		currentTarget, err := url.Parse(fmt.Sprintf("http://%s:%d", currentIP, containerPort))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid proxy target URL: %s", err), http.StatusBadGateway)
+			return
+		}
 		proxy := &httputil.ReverseProxy{
 			Director: func(req *http.Request) {
 				req.URL.Scheme = currentTarget.Scheme
@@ -579,7 +587,11 @@ func ServeSubdomainProxy(w http.ResponseWriter, r *http.Request, containerName s
 		return
 	}
 
-	currentTarget, _ := url.Parse(fmt.Sprintf("http://%s:%d", currentIP, containerPort))
+	currentTarget, err := url.Parse(fmt.Sprintf("http://%s:%d", currentIP, containerPort))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid proxy target URL: %s", err), http.StatusBadGateway)
+		return
+	}
 	proxy := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = currentTarget.Scheme

--- a/pkg/api/settings_handlers.go
+++ b/pkg/api/settings_handlers.go
@@ -366,7 +366,10 @@ func UpdateMCPSettingsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Load existing config to detect added/removed servers
-	oldCfg, _ := config.LoadMCPConfig()
+	oldCfg, err := config.LoadMCPConfig()
+	if err != nil {
+		slog.Warn("failed to load existing MCP config", "error", err)
+	}
 
 	// Set default transport to "stdio" if not specified
 	for name, server := range newCfg.MCPServers {

--- a/pkg/api/skills_handlers.go
+++ b/pkg/api/skills_handlers.go
@@ -302,7 +302,10 @@ func loadAPISkills() ([]skills.Skill, error) {
 		skillsCfg = appCfg.Skills
 	}
 
-	workDir, _ := os.Getwd()
+	workDir, wdErr := os.Getwd()
+	if wdErr != nil {
+		slog.Warn("failed to get working directory", "error", wdErr)
+	}
 	return skills.LoadSkills(
 		skillsCfg.GetUserSkillsDir(),
 		skillsCfg.ExtraDirs,

--- a/pkg/api/skills_handlers.go
+++ b/pkg/api/skills_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -189,7 +190,10 @@ func CreateSkillHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	appCfg, _ := config.LoadAppConfig()
+	appCfg, err := config.LoadAppConfig()
+	if err != nil {
+		slog.Warn("failed to load app config", "error", err)
+	}
 	var skillsCfg config.SkillsConfig
 	if appCfg != nil {
 		skillsCfg = appCfg.Skills
@@ -289,7 +293,10 @@ func DeleteSkillHandler(w http.ResponseWriter, r *http.Request) {
 // --- Helpers ---
 
 func loadAPISkills() ([]skills.Skill, error) {
-	appCfg, _ := config.LoadAppConfig()
+	appCfg, err := config.LoadAppConfig()
+	if err != nil {
+		slog.Warn("failed to load app config", "error", err)
+	}
 	var skillsCfg config.SkillsConfig
 	if appCfg != nil {
 		skillsCfg = appCfg.Skills

--- a/pkg/api/standard_servers_handler.go
+++ b/pkg/api/standard_servers_handler.go
@@ -109,7 +109,10 @@ func InstallStandardServerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Setup environment variables for the new MCP server
-	mcpCfg, _ := config.LoadMCPConfig()
+	mcpCfg, err := config.LoadMCPConfig()
+	if err != nil {
+		slog.Warn("failed to load MCP config", "error", err)
+	}
 	if mcpCfg != nil {
 		config.SetupMCPEnv(mcpCfg)
 	}

--- a/pkg/config/mcp_config.go
+++ b/pkg/config/mcp_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -84,7 +85,10 @@ func LoadMCPConfigRaw() (*MCPConfig, error) {
 // the credential store first, then config.yaml.
 // Keyless servers are always injected — they need no setup.
 func mergeStandardServers(cfg *MCPConfig) {
-	appCfg, _ := LoadAppConfig()
+	appCfg, err := LoadAppConfig()
+	if err != nil {
+		slog.Warn("failed to load app config for MCP server merge", "error", err)
+	}
 	getter := getInstalledSecretGetter()
 
 	// First: inject key-based servers that have credentials

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -85,7 +85,10 @@ func Run(cfg RunConfig) error {
 	defer RemovePID(pidPath)
 
 	// Set up provider environment variables (credential store → config → env fallback)
-	configDir, _ := config.GetConfigDir()
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		slog.Warn("failed to get config directory", "error", err)
+	}
 	var credStore *credentials.Store
 	if configDir != "" {
 		if cs, csErr := credentials.Open(configDir); csErr == nil {

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -496,7 +496,10 @@ func Run(cfg RunConfig) error {
 			// it can be injected as GH_TOKEN into gh CLI commands.
 			if credStore != nil {
 				activator.SetGHTokenResolver(func(plan *fleet.FleetPlan) string {
-					resolved, _ := fleet.ResolveCredentials(plan, credStore)
+					resolved, err := fleet.ResolveCredentials(plan, credStore)
+					if err != nil {
+						slog.Warn("failed to resolve fleet credentials", "plan", plan.Key, "error", err)
+					}
 					return fleet.GitHubToken(resolved)
 				})
 			}

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -378,7 +378,10 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			coreTools = append(coreTools, searchTool)
 		}
 
-		memDir, _ := config.GetMemoryDir(&cfg.AppConfig.Memory)
+		memDir, err := config.GetMemoryDir(&cfg.AppConfig.Memory)
+		if err != nil {
+			slog.Warn("failed to get memory directory", "error", err)
+		}
 		getTool, getErr := tools.NewMemoryGetTool(memDir)
 		if getErr != nil {
 			if cfg.DebugMode {
@@ -547,7 +550,10 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 	}
 
 	// --- 3. Load MCP tools from cache (lazy) ---
-	mcpCfg, _ := config.LoadMCPConfig()
+	mcpCfg, err := config.LoadMCPConfig()
+	if err != nil {
+		slog.Warn("failed to load MCP config", "error", err)
+	}
 	var lazyToolsets []*agent.LazyMCPToolset
 
 	if mcpCfg != nil && len(mcpCfg.MCPServers) > 0 {
@@ -984,10 +990,18 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 	// Load INSTRUCTIONS.md
 	var memDir string
 	if cfg.AppConfig != nil && cfg.AppConfig.Memory.IsMemoryEnabled() {
-		memDir, _ = config.GetMemoryDir(&cfg.AppConfig.Memory)
+		var err error
+		memDir, err = config.GetMemoryDir(&cfg.AppConfig.Memory)
+		if err != nil {
+			slog.Warn("failed to get memory directory from config", "error", err)
+		}
 	}
 	if memDir == "" {
-		memDir, _ = config.GetMemoryDir(nil)
+		var err error
+		memDir, err = config.GetMemoryDir(nil)
+		if err != nil {
+			slog.Warn("failed to get default memory directory", "error", err)
+		}
 	}
 	if memDir != "" {
 		created, ensErr := memory.EnsureInstructions(memDir)

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -130,7 +130,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 						slog.Warn("failed to save scrubbed config", "error", saveErr)
 					}
 				} else if cfg.DebugMode {
-					fmt.Printf("Migrated %d secrets from config.yaml to encrypted store\n", migrated)
+					slog.Debug("migrated secrets to encrypted store", "component", "chat-factory", "count", migrated)
 				}
 			}
 
@@ -151,8 +151,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 
 	// --- 1. Initialize LLM ---
 	if cfg.DebugMode {
-		fmt.Println("Initializing LLM provider...")
-		provider.SetDebugMode(true)
+		slog.Debug("initializing LLM provider", "component", "chat-factory")
 	}
 	llm, err := provider.GetProvider(ctx, cfg.ProviderName, cfg.ModelName, cfg.AppConfig)
 	if err != nil {
@@ -160,7 +159,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			cfg.ProviderName, cfg.ModelName, err)
 	}
 	if cfg.DebugMode {
-		fmt.Printf("Provider initialized: %s (model: %s)\n", cfg.ProviderName, cfg.ModelName)
+		slog.Debug("provider initialized", "component", "chat-factory", "provider", cfg.ProviderName, "model", cfg.ModelName)
 	}
 
 	// --- 2. Initialize internal tools ---
@@ -281,7 +280,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 						daemonActive := !cfg.IsDaemon && isDaemonRunning()
 						if daemonActive {
 							if cfg.DebugMode {
-								fmt.Println("[Memory] Daemon is running — skipping IndexAll and file watcher")
+								slog.Debug("daemon is running, skipping IndexAll and file watcher", "component", "memory")
 							}
 							close(indexingDone)
 						} else {
@@ -544,7 +543,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 				}
 			}
 			if cfg.DebugMode {
-				fmt.Printf("Skills loaded: %d total, %d eligible\n", len(loadedSkills), len(eligible))
+				slog.Debug("skills loaded", "component", "chat-factory", "total", len(loadedSkills), "eligible", len(eligible))
 			}
 		}
 	}
@@ -570,7 +569,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			cachedTools := cache.GetToolsForServer(name)
 			if len(cachedTools) == 0 {
 				if cfg.DebugMode {
-					fmt.Printf("[Chat Lazy] Server '%s' has no cached tools (run Studio or 'astonish tools refresh' first)\n", name)
+					slog.Debug("MCP server has no cached tools", "component", "lazy-mcp", "server", name)
 				}
 				continue
 			}
@@ -709,7 +708,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			nodePool.StartIdleWatchdog(idleCtx, idleTimeout)
 			cleanups = append(cleanups, idleCancel)
 			if cfg.DebugMode {
-				fmt.Printf("Sandbox idle watchdog: enabled (timeout: %s)\n", idleTimeout)
+				slog.Debug("sandbox idle watchdog enabled", "component", "chat-factory", "timeout", idleTimeout)
 			}
 		}
 
@@ -725,12 +724,12 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 		// Reuse the pre-created store (shared with fleet sessions in the daemon).
 		sessionService = cfg.SessionStore
 		if cfg.DebugMode {
-			fmt.Println("Session storage: file (shared store)")
+			slog.Debug("session storage: file (shared store)", "component", "chat-factory")
 		}
 	} else if cfg.AppConfig != nil && cfg.AppConfig.Sessions.Storage == "memory" {
 		sessionService = session.InMemoryService()
 		if cfg.DebugMode {
-			fmt.Println("Session storage: memory")
+			slog.Debug("session storage: memory", "component", "chat-factory")
 		}
 	} else {
 		var sessCfg *config.SessionConfig
@@ -749,7 +748,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 		}
 		sessionService = fileStore
 		if cfg.DebugMode {
-			fmt.Printf("Session storage: file (%s)\n", sessDir)
+			slog.Debug("session storage: file", "component", "chat-factory", "dir", sessDir)
 		}
 	}
 
@@ -891,8 +890,8 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 		for _, g := range toolGroups {
 			totalTools += len(g.Tools)
 		}
-		fmt.Printf("Tool groups: %d groups, %d total tools, %d main thread tools\n",
-			len(toolGroups), totalTools, len(mainThreadTools))
+		slog.Debug("tool groups configured", "component", "chat-factory",
+			"groups", len(toolGroups), "totalTools", totalTools, "mainThreadTools", len(mainThreadTools))
 	}
 
 	// --- 5. Build system prompt ---
@@ -1010,7 +1009,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 				slog.Warn("failed to ensure INSTRUCTIONS.md", "error", ensErr)
 			}
 		} else if created && cfg.DebugMode {
-			fmt.Printf("Created default INSTRUCTIONS.md in %s\n", memDir)
+			slog.Debug("created default INSTRUCTIONS.md", "component", "chat-factory", "dir", memDir)
 		}
 		instrContent, instrErr := memory.LoadInstructions(memDir)
 		if instrErr != nil {
@@ -1034,7 +1033,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 				slog.Warn("failed to write SELF.md", "error", writeErr)
 			}
 		} else if cfg.DebugMode {
-			fmt.Printf("Generated SELF.md (%d bytes)\n", len(selfContent))
+			slog.Debug("generated SELF.md", "component", "chat-factory", "bytes", len(selfContent))
 		}
 
 		// Sync guidance documents to memory/guidance/ for vector indexing.
@@ -1045,7 +1044,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 				slog.Warn("failed to sync guidance docs", "error", syncErr)
 			}
 		} else if cfg.DebugMode {
-			fmt.Printf("Synced guidance docs to memory/guidance/\n")
+			slog.Debug("synced guidance docs to memory/guidance/")
 		}
 	}
 
@@ -1071,7 +1070,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 				slog.Warn("failed to bootstrap bundled fleets", "error", fEnsErr)
 			}
 		} else if fWritten > 0 && cfg.DebugMode {
-			fmt.Printf("Bootstrapped %d bundled fleets to %s\n", fWritten, fleetsDir)
+			slog.Debug("bootstrapped bundled fleets", "count", fWritten, "dir", fleetsDir)
 		}
 
 		fleetReg, fRegErr := fleet.NewRegistry(fleetsDir)
@@ -1122,7 +1121,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 					},
 				)
 				if cfg.DebugMode {
-					fmt.Printf("Fleet awareness: %d fleet(s)\n", fleetReg.Count())
+					slog.Debug("fleet awareness", "fleets", fleetReg.Count())
 				}
 			}
 		}
@@ -1141,7 +1140,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 				// Wire plan registry to the save_fleet_plan tool
 				tools.SetFleetPlanRegistry(planReg)
 				if cfg.DebugMode {
-					fmt.Printf("Fleet plans: %d loaded from %s\n", planReg.Count(), fleetPlansDir)
+					slog.Debug("fleet plans loaded", "count", planReg.Count(), "dir", fleetPlansDir)
 				}
 			}
 		}
@@ -1276,7 +1275,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 					slog.Warn("failed to sync tool index", "error", syncErr)
 				}
 			} else if cfg.DebugMode {
-				fmt.Printf("Tool index: %d tools indexed for semantic discovery\n", toolIndex.Count())
+				slog.Debug("tool index ready", "tools_indexed", toolIndex.Count())
 			}
 		}
 	}
@@ -1378,7 +1377,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 						slog.Warn("flow registry sync failed", "error", syncErr)
 					}
 				} else if added > 0 && cfg.DebugMode {
-					fmt.Printf("Auto-registered %d new flows from %s\n", added, flowsDir)
+					slog.Debug("auto-registered new flows", "count", added, "dir", flowsDir)
 				}
 			}
 
@@ -1390,7 +1389,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 							slog.Warn("flow knowledge reconciliation failed", "error", reconErr)
 						}
 					} else if cfg.DebugMode {
-						fmt.Printf("Reconciled flow knowledge docs in %s\n", memFlowsDir)
+						slog.Debug("reconciled flow knowledge docs", "dir", memFlowsDir)
 					}
 				}
 			}
@@ -1434,7 +1433,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 		}
 
 		if cfg.DebugMode {
-			fmt.Println("Auto knowledge retrieval: enabled")
+			slog.Debug("auto knowledge retrieval: enabled")
 		}
 	}
 
@@ -1453,7 +1452,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			content := memory.GenerateSelfMD(selfCfg)
 			if writeErr := memory.WriteSelfMD(selfMDMemDir, content); writeErr == nil {
 				if cfg.DebugMode {
-					fmt.Printf("[SELF.md] Refreshed (%d bytes)\n", len(content))
+					slog.Debug("SELF.md refreshed", "bytes", len(content))
 				}
 			}
 		}
@@ -1499,8 +1498,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 			subAgentMgr.Compactor = compactor
 		}
 		if cfg.DebugMode {
-			fmt.Printf("Context compaction: enabled (window: %d tokens, threshold: %.0f%%)\n",
-				contextWindow, compactor.Threshold*100)
+			slog.Debug("context compaction enabled", "window_tokens", contextWindow, "threshold_pct", compactor.Threshold*100)
 		}
 	}
 

--- a/pkg/memory/hugot_embedder.go
+++ b/pkg/memory/hugot_embedder.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -81,7 +82,7 @@ func NewHugotEmbedder(modelsDir string, debugMode bool) (*HugotEmbedder, error) 
 	if _, err := os.Stat(modelPath); os.IsNotExist(err) {
 		fmt.Printf("Downloading embedding model (one-time, ~23 MB)...\n")
 		if debugMode {
-			fmt.Printf("[Hugot] Model: %s\n", DefaultEmbeddingModel)
+			slog.Debug("hugot downloading embedding model", "model", DefaultEmbeddingModel)
 		}
 		opts := hugot.NewDownloadOptions()
 		opts.Verbose = debugMode
@@ -93,7 +94,7 @@ func NewHugotEmbedder(modelsDir string, debugMode bool) (*HugotEmbedder, error) 
 		modelPath = downloadedPath
 		fmt.Printf("Embedding model ready.\n")
 	} else if debugMode {
-		fmt.Printf("[Hugot] Using cached model at %s\n", modelPath)
+		slog.Debug("hugot using cached model", "path", modelPath)
 	}
 
 	// Create Hugot session with pure Go backend (GoMLX simplego)

--- a/pkg/provider/anthropic/anthropic.go
+++ b/pkg/provider/anthropic/anthropic.go
@@ -88,7 +88,10 @@ func (p *Provider) GenerateContent(ctx context.Context, req *model.LLMRequest, s
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+			}
 			yield(nil, llmerror.NewFromResponse("anthropic", resp, body))
 			return
 		}
@@ -419,7 +422,10 @@ func fetchModels(ctx context.Context, apiKey string) ([]ModelInfo, error) {
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+			}
 			return nil, fmt.Errorf("API error: %s - %s", resp.Status, string(body))
 		}
 

--- a/pkg/provider/google/google.go
+++ b/pkg/provider/google/google.go
@@ -103,7 +103,10 @@ func ListModels(ctx context.Context, apiKey string) ([]string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return nil, fmt.Errorf("failed to fetch models: %s - %s", resp.Status, string(body))
 	}
 
@@ -132,18 +135,18 @@ func ListModels(ctx context.Context, apiKey string) ([]string, error) {
 
 // ModelInfo represents enhanced model metadata for Google AI
 type ModelInfo struct {
-	ID                  string `json:"id"`
-	Name                string `json:"name"`
-	DisplayName         string `json:"display_name,omitempty"`
-	Description         string `json:"description,omitempty"`
-	InputTokenLimit     int    `json:"context_length,omitempty"`
-	OutputTokenLimit    int    `json:"max_completion_tokens,omitempty"`
-	CreatedAt           string `json:"created_at,omitempty"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	DisplayName      string `json:"display_name,omitempty"`
+	Description      string `json:"description,omitempty"`
+	InputTokenLimit  int    `json:"context_length,omitempty"`
+	OutputTokenLimit int    `json:"max_completion_tokens,omitempty"`
+	CreatedAt        string `json:"created_at,omitempty"`
 }
 
 // nativeModelResponse represents a single model from the native API
 type nativeModelResponse struct {
-	Name                       string   `json:"name"`                       // e.g. "models/gemini-2.0-flash"
+	Name                       string   `json:"name"` // e.g. "models/gemini-2.0-flash"
 	DisplayName                string   `json:"displayName"`
 	Description                string   `json:"description"`
 	InputTokenLimit            int      `json:"inputTokenLimit"`
@@ -190,7 +193,10 @@ func ListModelsWithMetadata(ctx context.Context, apiKey string) ([]ModelInfo, er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return nil, fmt.Errorf("failed to fetch models: %s - %s", resp.Status, string(body))
 	}
 

--- a/pkg/provider/groq/groq.go
+++ b/pkg/provider/groq/groq.go
@@ -73,7 +73,10 @@ func fetchModels(ctx context.Context, apiKey string) ([]ModelInfo, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return nil, fmt.Errorf("failed to fetch models: %s - %s", resp.Status, string(body))
 	}
 

--- a/pkg/provider/lmstudio/lmstudio.go
+++ b/pkg/provider/lmstudio/lmstudio.go
@@ -64,7 +64,10 @@ func fetchModels(ctx context.Context, baseURL string) ([]ModelInfo, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return nil, fmt.Errorf("failed to fetch models: %s - %s", resp.Status, string(body))
 	}
 

--- a/pkg/provider/ollama/ollama.go
+++ b/pkg/provider/ollama/ollama.go
@@ -75,7 +75,10 @@ func fetchModels(ctx context.Context, baseURL string) ([]ModelInfo, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return nil, fmt.Errorf("failed to fetch models: %s - %s", resp.Status, string(body))
 	}
 

--- a/pkg/provider/poe/poe.go
+++ b/pkg/provider/poe/poe.go
@@ -70,7 +70,10 @@ func fetchModels(ctx context.Context, apiKey string) ([]ModelInfo, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return nil, fmt.Errorf("failed to fetch models: %s - %s", resp.Status, string(body))
 	}
 

--- a/pkg/provider/sap/sap.go
+++ b/pkg/provider/sap/sap.go
@@ -140,7 +140,10 @@ func resolveDeploymentIDWithConfig(ctx context.Context, modelName, clientID, cli
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return "", fmt.Errorf("failed to list deployments: %s, body: %s", resp.Status, string(body))
 	}
 
@@ -253,7 +256,10 @@ func (t *sapTransport) getToken() (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return "", fmt.Errorf("failed to get token: %s, body: %s", resp.Status, string(body))
 	}
 
@@ -376,7 +382,10 @@ func ResolveDeploymentID(ctx context.Context, modelName string) (string, error) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return "", fmt.Errorf("failed to list deployments: %s, body: %s", resp.Status, string(body))
 	}
 
@@ -450,7 +459,10 @@ func ListModels(ctx context.Context, clientID, clientSecret, authURL, baseURL, r
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return nil, fmt.Errorf("%s, body: %s", resp.Status, string(body))
 	}
 
@@ -593,7 +605,10 @@ func (p *Provider) generateBedrockContent(ctx context.Context, req *model.LLMReq
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+			}
 			yield(nil, llmerror.NewFromResponse("sap-bedrock", resp, body))
 			return
 		}
@@ -607,7 +622,10 @@ func (p *Provider) generateBedrockContent(ctx context.Context, req *model.LLMReq
 			}
 		} else {
 			// Non-streaming response
-			body, _ := io.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+			}
 			llmResp, err := bedrock.ParseResponse(body)
 			if err != nil {
 				yield(nil, err)
@@ -662,7 +680,10 @@ func (p *Provider) generateVertexContent(ctx context.Context, req *model.LLMRequ
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+			}
 			yield(nil, llmerror.NewFromResponse("sap-vertex", resp, body))
 			return
 		}
@@ -676,7 +697,10 @@ func (p *Provider) generateVertexContent(ctx context.Context, req *model.LLMRequ
 			}
 		} else {
 			// Non-streaming response
-			body, _ := io.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+			}
 			llmResp, err := vertex.ParseResponse(body)
 			if err != nil {
 				yield(nil, err)

--- a/pkg/provider/xai/models.go
+++ b/pkg/provider/xai/models.go
@@ -69,7 +69,10 @@ func fetchModels(ctx context.Context, apiKey string) ([]ModelInfo, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+		}
 		return nil, fmt.Errorf("failed to fetch models: %s - %s", resp.Status, string(body))
 	}
 

--- a/pkg/sandbox/exec.go
+++ b/pkg/sandbox/exec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
 	"strconv"
 	"sync"
 
@@ -210,7 +211,9 @@ func ExecInteractive(client *IncusClient, containerName string, command []string
 	// so that readers get EOF. This mirrors how local PTY gives EIO when
 	// the slave side closes.
 	go func() {
-		_ = op.Wait()
+		if err := op.Wait(); err != nil {
+			slog.Debug("interactive exec operation completed with error", "component", "sandbox", "error", err)
+		}
 		stdoutWriter.Close()
 		stdinReader.Close()
 	}()
@@ -275,7 +278,9 @@ func ExecNonInteractive(client *IncusClient, containerName string, command []str
 	cp.op = op
 
 	go func() {
-		_ = op.Wait()
+		if err := op.Wait(); err != nil {
+			slog.Debug("non-interactive exec operation completed with error", "component", "sandbox", "error", err)
+		}
 		stdoutWriter.Close()
 		stdinReader.Close()
 	}()

--- a/pkg/sandbox/lifecycle.go
+++ b/pkg/sandbox/lifecycle.go
@@ -89,7 +89,9 @@ func EnsureSessionContainer(client *IncusClient, sessRegistry *SessionRegistry, 
 		// Also clean the registry entry for whatever session owned this container
 		for _, entry := range sessRegistry.List() {
 			if entry.ContainerName == containerName && entry.SessionID != sessionID {
-				_ = sessRegistry.Remove(entry.SessionID)
+				if err := sessRegistry.Remove(entry.SessionID); err != nil {
+					slog.Warn("failed to remove stale registry entry", "component", "sandbox", "session", entry.SessionID, "error", err)
+				}
 				break
 			}
 		}
@@ -119,7 +121,9 @@ func EnsureSessionContainer(client *IncusClient, sessRegistry *SessionRegistry, 
 		// and deletes the Incus instance. If it fails (e.g., container in
 		// ABORTING state), fall back to a direct delete to avoid zombies.
 		if destroyErr := destroyOverlayContainer(client, containerName); destroyErr != nil {
-			_ = client.DeleteInstance(containerName)
+			if delErr := client.DeleteInstance(containerName); delErr != nil {
+				slog.Warn("fallback delete also failed after start failure", "component", "sandbox", "container", containerName, "error", delErr)
+			}
 		}
 		if lxcLog != "" {
 			return "", fmt.Errorf("failed to start session container: %w\n\nLXC log:\n%s", err, lxcLog)
@@ -132,7 +136,9 @@ func EnsureSessionContainer(client *IncusClient, sessRegistry *SessionRegistry, 
 	// but has an empty/wrong filesystem (just the tiny shell image).
 	if err := verifyContainerHealth(client, containerName); err != nil {
 		if destroyErr := destroyOverlayContainer(client, containerName); destroyErr != nil {
-			_ = client.DeleteInstance(containerName)
+			if delErr := client.DeleteInstance(containerName); delErr != nil {
+				slog.Warn("fallback delete also failed after health check failure", "component", "sandbox", "container", containerName, "error", delErr)
+			}
 		}
 		return "", fmt.Errorf("session container health check failed: %w", err)
 	}
@@ -142,7 +148,9 @@ func EnsureSessionContainer(client *IncusClient, sessRegistry *SessionRegistry, 
 		// Registry write failed — the container works but won't be tracked.
 		// Destroy it so we don't leak an untracked container.
 		if destroyErr := destroyOverlayContainer(client, containerName); destroyErr != nil {
-			_ = client.DeleteInstance(containerName)
+			if delErr := client.DeleteInstance(containerName); delErr != nil {
+				slog.Warn("fallback delete also failed after registry write failure", "component", "sandbox", "container", containerName, "error", delErr)
+			}
 		}
 		return "", fmt.Errorf("failed to register session container: %w", err)
 	}
@@ -270,7 +278,9 @@ func TryDestroySessionContainer(sessionID string) {
 
 	// Try the registry-based path first (finds container by session ID lookup)
 	if entry := registry.Get(sessionID); entry != nil {
-		_ = DestroyForSession(client, registry, sessionID)
+		if err := DestroyForSession(client, registry, sessionID); err != nil {
+			slog.Warn("failed to destroy session container via registry", "component", "sandbox", "session", sessionID, "error", err)
+		}
 		return
 	}
 
@@ -280,7 +290,9 @@ func TryDestroySessionContainer(sessionID string) {
 	// Try to destroy by the derived container name directly.
 	containerName := SessionContainerName(sessionID)
 	if client.InstanceExists(containerName) {
-		_ = destroyOverlayContainer(client, containerName)
+		if err := destroyOverlayContainer(client, containerName); err != nil {
+			slog.Warn("failed to destroy orphan container", "component", "sandbox", "container", containerName, "error", err)
+		}
 	}
 }
 
@@ -392,7 +404,9 @@ func PruneStaleOnStartup(client *IncusClient, registry *SessionRegistry, existin
 		// Derive the session ID from the container name and check the store.
 		if matchedID := matchContainerToSession(inst.Name, existingSessionIDs); matchedID != "" {
 			// Self-heal: re-register so future lookups work.
-			_ = registry.Put(matchedID, inst.Name, BaseTemplate)
+			if err := registry.Put(matchedID, inst.Name, BaseTemplate); err != nil {
+				slog.Warn("failed to self-heal registry entry", "component", "sandbox", "session", matchedID, "container", inst.Name, "error", err)
+			}
 			continue
 		}
 
@@ -404,7 +418,9 @@ func PruneStaleOnStartup(client *IncusClient, registry *SessionRegistry, existin
 		// Also clean registry entry if one exists
 		for _, entry := range registry.List() {
 			if entry.ContainerName == inst.Name {
-				_ = registry.Remove(entry.SessionID)
+				if err := registry.Remove(entry.SessionID); err != nil {
+					slog.Warn("failed to remove registry entry for pruned container", "component", "sandbox", "container", inst.Name, "error", err)
+				}
 				break
 			}
 		}

--- a/pkg/sandbox/node.go
+++ b/pkg/sandbox/node.go
@@ -578,14 +578,18 @@ func (lnc *LazyNodeClient) Cleanup() {
 		if lnc.containerName != "" && lnc.incusClient != nil {
 			// Use destroyOverlayContainer to properly unmount overlayfs
 			// and clean up overlay dirs before deleting the container.
-			_ = destroyOverlayContainer(lnc.incusClient, lnc.containerName)
+			if err := destroyOverlayContainer(lnc.incusClient, lnc.containerName); err != nil {
+				slog.Warn("failed to destroy overlay container during cleanup", "component", "sandbox", "container", lnc.containerName, "error", err)
+			}
 		}
 
 		if lnc.containerName != "" && lnc.sessRegistry != nil {
 			// Find and remove the session registry entry for this container
 			for _, entry := range lnc.sessRegistry.List() {
 				if entry.ContainerName == lnc.containerName {
-					_ = lnc.sessRegistry.Remove(entry.SessionID)
+					if err := lnc.sessRegistry.Remove(entry.SessionID); err != nil {
+						slog.Warn("failed to remove session registry entry", "component", "sandbox", "session", entry.SessionID, "error", err)
+					}
 					break
 				}
 			}
@@ -621,7 +625,9 @@ func (lnc *LazyNodeClient) CleanupForShutdown() {
 	// EnsureSessionContainer will re-mount and restart it later.
 	if lnc.containerName != "" && lnc.incusClient != nil {
 		if lnc.incusClient.IsRunning(lnc.containerName) {
-			_ = lnc.incusClient.StopInstance(lnc.containerName, true)
+			if err := lnc.incusClient.StopInstance(lnc.containerName, true); err != nil {
+				slog.Warn("failed to stop container for shutdown", "component", "sandbox", "container", lnc.containerName, "error", err)
+			}
 		}
 	}
 
@@ -654,7 +660,9 @@ func (lnc *LazyNodeClient) StopForIdle() {
 	// EnsureSessionContainer will re-mount and restart it on the next tool call.
 	if lnc.containerName != "" && lnc.incusClient != nil {
 		if lnc.incusClient.IsRunning(lnc.containerName) {
-			_ = lnc.incusClient.StopInstance(lnc.containerName, true)
+			if err := lnc.incusClient.StopInstance(lnc.containerName, true); err != nil {
+				slog.Warn("failed to stop container for idle", "component", "sandbox", "container", lnc.containerName, "error", err)
+			}
 		}
 	}
 
@@ -912,7 +920,9 @@ func (p *NodeClientPool) GetOrCreate(sessionID string) *LazyNodeClient {
 		delete(p.clients, sessionID)
 		// Don't call client.Cleanup() here — the container may be reusable.
 		// Close the node client (if any) but leave the container intact.
-		_ = client.Close()
+		if err := client.Close(); err != nil {
+			slog.Warn("failed to close stale client", "component", "sandbox", "session", sessionID[:min(8, len(sessionID))], "error", err)
+		}
 	}
 
 	// Create a new LazyNodeClient for this session
@@ -959,7 +969,9 @@ func (p *NodeClientPool) Remove(sessionID string) {
 	p.mu.Unlock()
 
 	if ok && client != nil {
-		_ = client.Close()
+		if err := client.Close(); err != nil {
+			slog.Warn("failed to close client during pool remove", "component", "sandbox", "session", sessionID[:min(8, len(sessionID))], "error", err)
+		}
 	}
 }
 

--- a/pkg/sandbox/overlay.go
+++ b/pkg/sandbox/overlay.go
@@ -546,20 +546,27 @@ func CleanupAllOverlays() {
 
 		// Try to find and unmount the corresponding container rootfs
 		// We don't know the pool path here, so just try to unmount by reading /proc/mounts
-		data, _ := readMountsOnSandboxHost()
+		data, readErr := readMountsOnSandboxHost()
+		if readErr != nil {
+			slog.Warn("failed to read mounts during overlay cleanup", "component", "sandbox", "error", readErr)
+		}
 		for _, line := range bytes.Split(data, []byte("\n")) {
 			fields := bytes.Fields(line)
 			if len(fields) >= 3 && string(fields[2]) == "overlay" {
 				mountpoint := string(fields[1])
 				// Check if this mount's workdir points to our session dir
 				if bytes.Contains(line, []byte(filepath.Join(overlayBaseDir, name))) {
-					_ = umountOnSandboxHost(mountpoint)
+					if err := umountOnSandboxHost(mountpoint); err != nil {
+						slog.Warn("failed to unmount overlay during cleanup", "component", "sandbox", "mountpoint", mountpoint, "error", err)
+					}
 				}
 			}
 		}
 	}
 
-	_ = removeAllOnSandboxHost(overlayBaseDir)
+	if err := removeAllOnSandboxHost(overlayBaseDir); err != nil {
+		slog.Warn("failed to remove overlay base directory", "component", "sandbox", "path", overlayBaseDir, "error", err)
+	}
 }
 
 // RemountDependentOverlays finds all overlay mounts whose lowerdir includes

--- a/pkg/sandbox/template.go
+++ b/pkg/sandbox/template.go
@@ -547,7 +547,9 @@ func PromoteTemplate(client *IncusClient, registry *TemplateRegistry, name strin
 			return fmt.Errorf("failed to mount merged overlay: %w", err)
 		}
 		defer func() {
-			_ = umountOnSandboxHost(mergedDir)
+			if err := umountOnSandboxHost(mergedDir); err != nil {
+				slog.Warn("failed to unmount merged overlay", "component", "sandbox", "path", mergedDir, "error", err)
+			}
 		}()
 
 		// Stop and unmount old @base overlay (if any)
@@ -557,7 +559,9 @@ func PromoteTemplate(client *IncusClient, registry *TemplateRegistry, name strin
 			}
 		}
 		if IsOverlayMounted(poolPath, baseName) {
-			_ = UnmountSessionOverlay(poolPath, baseName)
+			if err := UnmountSessionOverlay(poolPath, baseName); err != nil {
+				slog.Warn("failed to unmount old @base overlay", "component", "sandbox", "container", baseName, "error", err)
+			}
 		}
 
 		// Delete old @base snapshot and container
@@ -700,7 +704,11 @@ func DeleteTemplate(client *IncusClient, registry *TemplateRegistry, name string
 	poolName, poolErr := GetPoolForProfile(client)
 	var poolPath string
 	if poolErr == nil {
-		poolPath, _ = GetPoolSourcePath(client, poolName)
+		var pathErr error
+		poolPath, pathErr = GetPoolSourcePath(client, poolName)
+		if pathErr != nil {
+			slog.Warn("failed to get pool source path", "component", "sandbox", "pool", poolName, "error", pathErr)
+		}
 	}
 
 	// Unmount any active overlay before deleting
@@ -937,14 +945,18 @@ func CreateTemplateFromContainer(client *IncusClient, registry *TemplateRegistry
 	tplUpperDir := OverlayUpperDir(tplContainerName)
 
 	if err := mkdirAllOnSandboxHost(filepath.Dir(tplUpperDir), 0755); err != nil {
-		_ = client.DeleteInstance(tplContainerName)
+		if delErr := client.DeleteInstance(tplContainerName); delErr != nil {
+			slog.Warn("failed to delete template instance during rollback", "component", "sandbox", "container", tplContainerName, "error", delErr)
+		}
 		restartSession()
 		return fmt.Errorf("failed to create template overlay dir: %w", err)
 	}
 
 	slog.Info("copying session overlay to template", "component", "sandbox", "template", tplContainerName)
 	if err := cpOnSandboxHost(sessionUpperDir, tplUpperDir); err != nil {
-		_ = client.DeleteInstance(tplContainerName)
+		if delErr := client.DeleteInstance(tplContainerName); delErr != nil {
+			slog.Warn("failed to delete template instance during rollback", "component", "sandbox", "container", tplContainerName, "error", delErr)
+		}
 		restartSession()
 		return fmt.Errorf("failed to copy session overlay: %w", err)
 	}
@@ -963,18 +975,25 @@ func CreateTemplateFromContainer(client *IncusClient, registry *TemplateRegistry
 	// from the parent template that the session inherited.
 	lowerDir, err := ResolveLowerLayers(poolPath, sourceTemplate, registry)
 	if err != nil {
-		_ = client.DeleteInstance(tplContainerName)
+		if delErr := client.DeleteInstance(tplContainerName); delErr != nil {
+			slog.Warn("failed to delete template instance during rollback", "component", "sandbox", "container", tplContainerName, "error", delErr)
+		}
 		restartSession()
 		return fmt.Errorf("failed to resolve lower layers for source template %q: %w", sourceTemplate, err)
 	}
 	if err := MountOverlay(poolPath, tplContainerName, lowerDir); err != nil {
-		_ = client.DeleteInstance(tplContainerName)
+		if delErr := client.DeleteInstance(tplContainerName); delErr != nil {
+			slog.Warn("failed to delete template instance during rollback", "component", "sandbox", "container", tplContainerName, "error", delErr)
+		}
 		restartSession()
 		return fmt.Errorf("failed to mount overlay on template: %w", err)
 	}
 
 	// Compute binary hash
-	hash, _ := ComputeBinaryHash()
+	hash, hashErr := ComputeBinaryHash()
+	if hashErr != nil {
+		slog.Warn("failed to compute binary hash for template metadata", "component", "sandbox", "error", hashErr)
+	}
 
 	// Register in the template registry (overlay-based, no Incus snapshot)
 	now := time.Now()

--- a/pkg/session/compaction.go
+++ b/pkg/session/compaction.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -156,9 +157,7 @@ func (c *Compactor) CompactContents(ctx context.Context, contents []*genai.Conte
 	// Build summary
 	summary, err := c.summarize(ctx, oldContents)
 	if err != nil {
-		if c.DebugMode {
-			fmt.Printf("[Compactor] Summarization failed, falling back to truncation: %v\n", err)
-		}
+		slog.Debug("compactor summarization failed, falling back to truncation", "component", "compactor", "error", err)
 		// Fallback: just keep recent messages with a note
 		summary = c.truncationSummary(oldContents)
 	}
@@ -189,8 +188,8 @@ func (c *Compactor) CompactContents(ctx context.Context, contents []*genai.Conte
 	c.mu.Unlock()
 
 	if c.DebugMode {
-		fmt.Printf("[Compactor] Compacted %d → %d messages (estimated %d tokens)\n",
-			len(contents), len(result), EstimateTokens(result))
+		slog.Debug("compacted messages", "component", "compactor",
+			"before", len(contents), "after", len(result), "estimatedTokens", EstimateTokens(result))
 	}
 
 	return result, nil
@@ -301,15 +300,14 @@ func (c *Compactor) BeforeModelCallback() llmagent.BeforeModelCallback {
 
 		if c.DebugMode {
 			est := EstimateTokens(req.Contents)
-			fmt.Printf("[Compactor] Threshold exceeded (%d/%d tokens, %.0f%%). Compacting...\n",
-				est, c.ContextWindow, float64(est)/float64(c.ContextWindow)*100)
+			slog.Debug("compactor threshold exceeded, compacting",
+				"component", "compactor", "tokens", est, "window", c.ContextWindow,
+				"usage", fmt.Sprintf("%.0f%%", float64(est)/float64(c.ContextWindow)*100))
 		}
 
 		compacted, err := c.CompactContents(ctx, req.Contents)
 		if err != nil {
-			if c.DebugMode {
-				fmt.Printf("[Compactor] Compaction failed: %v\n", err)
-			}
+			slog.Debug("compaction failed", "component", "compactor", "error", err)
 			return nil, nil // proceed with original contents
 		}
 

--- a/pkg/skills/watcher.go
+++ b/pkg/skills/watcher.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,9 +45,7 @@ func WatchSkillDirs(ctx context.Context, cfg WatcherConfig) error {
 	// Collect all skill source directories to watch
 	dirs := collectSkillDirs(cfg)
 	if len(dirs) == 0 {
-		if cfg.DebugMode {
-			fmt.Println("[Skills Watcher] No skill directories to watch")
-		}
+		slog.Debug("no skill directories to watch", "component", "skills-watcher")
 		// Block until cancelled — nothing to watch
 		<-ctx.Done()
 		return nil
@@ -75,7 +74,7 @@ func WatchSkillDirs(ctx context.Context, cfg WatcherConfig) error {
 	}
 
 	if cfg.DebugMode {
-		fmt.Printf("[Skills Watcher] Watching %d skill directories\n", len(dirs))
+		slog.Debug("watching skill directories", "component", "skills-watcher", "count", len(dirs))
 	}
 
 	// Debounce: wait for changes to settle before re-syncing
@@ -93,24 +92,24 @@ func WatchSkillDirs(ctx context.Context, cfg WatcherConfig) error {
 		mu.Unlock()
 
 		if cfg.DebugMode {
-			fmt.Println("[Skills Watcher] Skill change detected, re-syncing to memory...")
+			slog.Debug("skill change detected, re-syncing to memory", "component", "skills-watcher")
 		}
 
 		allSkills, err := LoadSkills(cfg.UserDir, cfg.ExtraDirs, cfg.WorkspaceDir, cfg.Allowlist)
 		if err != nil {
 			if cfg.DebugMode {
-				fmt.Printf("[Skills Watcher] Error loading skills: %v\n", err)
+				slog.Debug("error loading skills", "component", "skills-watcher", "error", err)
 			}
 			return
 		}
 
 		if err := SyncSkillsToMemory(allSkills, cfg.MemoryDir); err != nil {
 			if cfg.DebugMode {
-				fmt.Printf("[Skills Watcher] Error syncing to memory: %v\n", err)
+				slog.Debug("error syncing skills to memory", "component", "skills-watcher", "error", err)
 			}
 		} else if cfg.DebugMode {
 			eligible := FilterEligible(allSkills)
-			fmt.Printf("[Skills Watcher] Synced %d eligible skills to memory\n", len(eligible))
+			slog.Debug("synced skills to memory", "component", "skills-watcher", "eligible", len(eligible))
 		}
 	}
 
@@ -134,14 +133,10 @@ func WatchSkillDirs(ctx context.Context, cfg WatcherConfig) error {
 					// If a skill root was recreated, re-watch it and its children
 					if skillRoots[event.Name] {
 						watchDirRecursive(watcher, event.Name, cfg.DebugMode)
-						if cfg.DebugMode {
-							fmt.Printf("[Skills Watcher] Re-watching recreated skill root: %s\n", event.Name)
-						}
+						slog.Debug("re-watching recreated skill root", "component", "skills-watcher", "dir", event.Name)
 					} else {
 						_ = watcher.Add(event.Name)
-						if cfg.DebugMode {
-							fmt.Printf("[Skills Watcher] Watching new directory: %s\n", event.Name)
-						}
+						slog.Debug("watching new directory", "component", "skills-watcher", "dir", event.Name)
 					}
 					// New directory likely already contains files (e.g. skills install
 					// creates dir + writes SKILL.md atomically before the watch is set up).
@@ -197,9 +192,7 @@ func WatchSkillDirs(ctx context.Context, cfg WatcherConfig) error {
 			if !ok {
 				return nil
 			}
-			if cfg.DebugMode {
-				fmt.Printf("[Skills Watcher] Error: %v\n", err)
-			}
+			slog.Debug("skills watcher error", "component", "skills-watcher", "error", err)
 		}
 	}
 }
@@ -239,9 +232,7 @@ func collectSkillDirs(cfg WatcherConfig) []string {
 // watchDirRecursive adds a watch on the directory and its immediate subdirectories.
 func watchDirRecursive(watcher *fsnotify.Watcher, dir string, debugMode bool) {
 	if err := watcher.Add(dir); err != nil {
-		if debugMode {
-			fmt.Printf("[Skills Watcher] Cannot watch %s: %v\n", dir, err)
-		}
+		slog.Debug("cannot watch directory", "component", "skills-watcher", "dir", dir, "error", err)
 		return
 	}
 
@@ -252,8 +243,8 @@ func watchDirRecursive(watcher *fsnotify.Watcher, dir string, debugMode bool) {
 	for _, e := range entries {
 		if e.IsDir() {
 			subDir := filepath.Join(dir, e.Name())
-			if err := watcher.Add(subDir); err != nil && debugMode {
-				fmt.Printf("[Skills Watcher] Cannot watch %s: %v\n", subDir, err)
+			if err := watcher.Add(subDir); err != nil {
+				slog.Debug("cannot watch subdirectory", "component", "skills-watcher", "dir", subDir, "error", err)
 			}
 		}
 	}

--- a/pkg/tools/drill_tool.go
+++ b/pkg/tools/drill_tool.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -585,7 +586,10 @@ func deleteDrill(_ tool.Context, args DeleteDrillArgs) (DeleteDrillResult, error
 	if !args.DeleteTests {
 		// Check if there are actually tests — if so, default to deleting them
 		// This handles the common case where the AI omits delete_tests entirely
-		tests, _ := adrill.FindTestsForSuite(dirs, args.SuiteName)
+		tests, findErr := adrill.FindTestsForSuite(dirs, args.SuiteName)
+		if findErr != nil {
+			slog.Warn("failed to find tests for suite", "suite", args.SuiteName, "error", findErr)
+		}
 		if len(tests) > 0 {
 			deleteTests = true
 		}

--- a/pkg/tools/memory_save.go
+++ b/pkg/tools/memory_save.go
@@ -92,7 +92,10 @@ func MemorySave(mgr *memory.Manager, store MemorySaveStore) func(ctx tool.Contex
 		}
 
 		// Read existing content
-		existing, _ := os.ReadFile(absPath)
+		existing, readErr := os.ReadFile(absPath)
+		if readErr != nil && !os.IsNotExist(readErr) {
+			slog.Debug("failed to read existing memory file", "path", absPath, "error", readErr)
+		}
 		existingStr := string(existing)
 
 		// Append content under category heading

--- a/pkg/tools/run_drill_tool.go
+++ b/pkg/tools/run_drill_tool.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -195,7 +196,10 @@ func executeRunDrill(ctx tool.Context, deps *runDrillDeps, args RunDrillArgs) (R
 	}
 
 	// Create artifact manager
-	reportsDir, _ := config.GetReportsDir()
+	reportsDir, err := config.GetReportsDir()
+	if err != nil {
+		slog.Warn("failed to get reports directory", "error", err)
+	}
 	reportDir := filepath.Join(reportsDir, suiteName)
 	am, amErr := adrill.NewArtifactManager(reportDir, suiteName)
 	if amErr != nil {

--- a/pkg/tools/schedule_tool.go
+++ b/pkg/tools/schedule_tool.go
@@ -476,7 +476,10 @@ type SchedulerHTTPAccess struct {
 }
 
 func (s *SchedulerHTTPAccess) AddJob(job *SchedulerJob) error {
-	data, _ := json.Marshal(job)
+	data, err := json.Marshal(job)
+	if err != nil {
+		return fmt.Errorf("failed to marshal job: %w", err)
+	}
 	resp, err := http.Post(s.BaseURL+"/api/scheduler/jobs", "application/json", strings.NewReader(string(data)))
 	if err != nil {
 		return fmt.Errorf("failed to contact daemon: %w", err)
@@ -528,7 +531,10 @@ func (s *SchedulerHTTPAccess) RemoveJob(id string) error {
 }
 
 func (s *SchedulerHTTPAccess) UpdateJob(job *SchedulerJob) error {
-	data, _ := json.Marshal(job)
+	data, err := json.Marshal(job)
+	if err != nil {
+		return fmt.Errorf("failed to marshal job: %w", err)
+	}
 	req, err := http.NewRequest(http.MethodPut, s.BaseURL+"/api/scheduler/jobs/"+job.ID, strings.NewReader(string(data)))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)

--- a/pkg/tools/schedule_tool.go
+++ b/pkg/tools/schedule_tool.go
@@ -512,7 +512,10 @@ func (s *SchedulerHTTPAccess) ListJobs() []*SchedulerJob {
 }
 
 func (s *SchedulerHTTPAccess) RemoveJob(id string) error {
-	req, _ := http.NewRequest(http.MethodDelete, s.BaseURL+"/api/scheduler/jobs/"+id, nil)
+	req, err := http.NewRequest(http.MethodDelete, s.BaseURL+"/api/scheduler/jobs/"+id, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
@@ -526,7 +529,10 @@ func (s *SchedulerHTTPAccess) RemoveJob(id string) error {
 
 func (s *SchedulerHTTPAccess) UpdateJob(job *SchedulerJob) error {
 	data, _ := json.Marshal(job)
-	req, _ := http.NewRequest(http.MethodPut, s.BaseURL+"/api/scheduler/jobs/"+job.ID, strings.NewReader(string(data)))
+	req, err := http.NewRequest(http.MethodPut, s.BaseURL+"/api/scheduler/jobs/"+job.ID, strings.NewReader(string(data)))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

Hardening plan v3, phases 1–6: systematic elimination of nil-pointer panics, silent error discards, and unstructured debug prints across the Go backend.

## Changes by Phase

### Phase 1 — Fix nil-pointer panics (8 sites)
- Check `http.NewRequest` and `url.Parse` return errors before dereferencing, across `schedule_tool.go`, `scheduler.go`, `fleet.go`, `sandbox_proxy.go`

### Phase 2 — Log silent config load failures (24 sites, 15 files)
- Config/setup errors that were silently discarded now logged with `slog.Warn`/`slog.Error`

### Phase 3 — Log silent fleet/credential failures (4 sites, 3 files)
- Fleet registry and credential resolution errors now logged instead of swallowed

### Phase 4 — Log silent sandbox cleanup errors (~27 sites, 5 files)
- Sandbox lifecycle, overlay, template, exec, and node cleanup errors now logged

### Phase 5 — Log remaining silent errors (~40 sites, 22 files)
- API handlers, tools, providers, and CLI commands — all remaining silently-discarded errors now logged

### Phase 6 — Migrate debug prints to slog (70 instances, 7 files)
- Replaced 70 debug-gated `fmt.Printf`/`fmt.Println` with structured `slog.Debug` calls
- Files: `memory_reflection.go` (16), `watcher.go` (11), `error_recovery.go` (9), `lazy_mcp_toolset.go` (5), `compaction.go` (4), `chat_factory.go` (23), `hugot_embedder.go` (2)
- 3 user-facing progress messages intentionally kept as `fmt.Printf`

## Testing
- `go build ./...` — passes
- `go test ./...` — all tests pass