### PR TITLE
Add hybrid search (Vector + BM25 + RRF) to memory store

### DIFF
--- a/cmd/astonish/memory.go
+++ b/cmd/astonish/memory.go
@@ -184,7 +184,7 @@ func handleMemorySearchCommand(args []string) error {
 	fmt.Printf("Indexed %d chunks in %s. Searching...\n\n", chunkCount, indexTime.Round(time.Millisecond))
 
 	// Run search
-	results, err := env.store.Search(context.Background(), query, *maxResults, *minScore)
+	results, err := env.store.SearchHybrid(context.Background(), query, *maxResults, *minScore)
 	if err != nil {
 		return fmt.Errorf("search failed: %w", err)
 	}

--- a/pkg/launcher/chat_factory.go
+++ b/pkg/launcher/chat_factory.go
@@ -1415,7 +1415,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 	// --- 6b2. Wire knowledge search callbacks ---
 	if memorySearchAvailable && memStore != nil {
 		chatAgent.KnowledgeSearch = func(ctx context.Context, query string, maxResults int, minScore float64) ([]agent.KnowledgeSearchResult, error) {
-			results, err := memStore.Search(ctx, query, maxResults, minScore)
+			results, err := memStore.SearchHybrid(ctx, query, maxResults, minScore)
 			if err != nil {
 				return nil, err
 			}
@@ -1432,7 +1432,7 @@ func NewWiredChatAgent(ctx context.Context, cfg *ChatFactoryConfig) (*ChatFactor
 		}
 
 		chatAgent.KnowledgeSearchByCategory = func(ctx context.Context, query string, maxResults int, minScore float64, category string) ([]agent.KnowledgeSearchResult, error) {
-			results, err := memStore.SearchByCategory(ctx, query, maxResults, minScore, category)
+			results, err := memStore.SearchHybridByCategory(ctx, query, maxResults, minScore, category)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/memory/bm25.go
+++ b/pkg/memory/bm25.go
@@ -1,0 +1,241 @@
+package memory
+
+import (
+	"math"
+	"sort"
+	"unicode"
+)
+
+// bm25Index is a TF-IDF inverted index for keyword-based search.
+// It stores pre-computed TF-IDF weights so queries are O(query_terms * matching_docs).
+// This complements the vector (embedding) search by catching keyword matches
+// that semantic embeddings miss due to "proper noun dilution" — where specific
+// terms (product specs, model numbers) shift the dense embedding away from
+// relevant documents, but keyword matching on known terms still works.
+type bm25Index struct {
+	// idf maps term → inverse document frequency: log(1 + N/df)
+	idf map[string]float64
+	// docTermFreqs maps docID → {term → sublinear TF-IDF weight}
+	docTermFreqs map[string]map[string]float64
+	// docNorms maps docID → L2 norm of the TF-IDF vector (for cosine normalization)
+	docNorms map[string]float64
+	// docMeta maps docID → metadata
+	docMeta map[string]bm25DocMeta
+	// totalDocs is the number of documents in the index
+	totalDocs int
+}
+
+// bm25DocMeta holds the metadata needed to build SearchResult from BM25 hits.
+type bm25DocMeta struct {
+	path      string
+	startLine int
+	endLine   int
+	category  string
+	content   string // chunk text (for snippet)
+}
+
+// bm25InputDoc is the input format for building a BM25 index.
+type bm25InputDoc struct {
+	ID        string
+	Content   string
+	Path      string
+	StartLine int
+	EndLine   int
+	Category  string
+}
+
+// bm25Result is a single BM25 search result.
+type bm25Result struct {
+	docID     string
+	path      string
+	startLine int
+	endLine   int
+	category  string
+	content   string
+	score     float64
+}
+
+// bm25Tokenize splits text into lowercase alphanumeric tokens.
+// Non-alphanumeric characters (including underscores) are token separators.
+func bm25Tokenize(s string) []string {
+	var tokens []string
+	var current []rune
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			current = append(current, unicode.ToLower(r))
+		} else {
+			if len(current) > 0 {
+				tokens = append(tokens, string(current))
+				current = current[:0]
+			}
+		}
+	}
+	if len(current) > 0 {
+		tokens = append(tokens, string(current))
+	}
+	return tokens
+}
+
+// buildBM25 constructs a BM25 inverted index from a set of input documents.
+// Each document's Content is tokenized and scored with sublinear TF * IDF.
+func buildBM25(docs []bm25InputDoc) *bm25Index {
+	n := len(docs)
+	if n == 0 {
+		return nil
+	}
+
+	// Step 1: Compute raw term frequencies per document
+	type docTF struct {
+		terms map[string]int
+	}
+	docTFs := make(map[string]*docTF, n)
+	docDF := make(map[string]int) // term → number of docs containing it
+
+	for _, doc := range docs {
+		tf := &docTF{terms: make(map[string]int)}
+		seen := make(map[string]bool)
+		tokens := bm25Tokenize(doc.Content)
+		for _, tok := range tokens {
+			tf.terms[tok]++
+			if !seen[tok] {
+				docDF[tok]++
+				seen[tok] = true
+			}
+		}
+		docTFs[doc.ID] = tf
+	}
+
+	// Step 2: Compute IDF for each term: log(1 + N/df)
+	idf := make(map[string]float64, len(docDF))
+	for term, df := range docDF {
+		idf[term] = math.Log(1.0 + float64(n)/float64(df))
+	}
+
+	// Step 3: Compute sublinear TF-IDF vectors and L2 norms
+	docTermFreqs := make(map[string]map[string]float64, n)
+	docNorms := make(map[string]float64, n)
+	docMeta := make(map[string]bm25DocMeta, n)
+
+	for _, doc := range docs {
+		tf := docTFs[doc.ID]
+		tfidf := make(map[string]float64, len(tf.terms))
+		var normSq float64
+		for term, rawTF := range tf.terms {
+			// Sublinear TF: 1 + log(tf)
+			subTF := 1.0 + math.Log(float64(rawTF))
+			w := subTF * idf[term]
+			tfidf[term] = w
+			normSq += w * w
+		}
+		docTermFreqs[doc.ID] = tfidf
+		if normSq > 0 {
+			docNorms[doc.ID] = math.Sqrt(normSq)
+		}
+
+		docMeta[doc.ID] = bm25DocMeta{
+			path:      doc.Path,
+			startLine: doc.StartLine,
+			endLine:   doc.EndLine,
+			category:  doc.Category,
+			content:   doc.Content,
+		}
+	}
+
+	return &bm25Index{
+		idf:          idf,
+		docTermFreqs: docTermFreqs,
+		docNorms:     docNorms,
+		docMeta:      docMeta,
+		totalDocs:    n,
+	}
+}
+
+// search scores all documents against the query using cosine similarity
+// on TF-IDF vectors. If category is non-empty, only documents with that
+// category are considered. Returns results sorted by score descending.
+func (b *bm25Index) search(query string, topK int, category string) []bm25Result {
+	if b == nil || b.totalDocs == 0 {
+		return nil
+	}
+
+	queryTokens := bm25Tokenize(query)
+	if len(queryTokens) == 0 {
+		return nil
+	}
+
+	// Build query TF-IDF vector
+	queryTF := make(map[string]int)
+	for _, tok := range queryTokens {
+		queryTF[tok]++
+	}
+	queryVec := make(map[string]float64, len(queryTF))
+	var queryNormSq float64
+	for term, rawTF := range queryTF {
+		termIDF, ok := b.idf[term]
+		if !ok {
+			continue // term not in any document
+		}
+		w := (1.0 + math.Log(float64(rawTF))) * termIDF
+		queryVec[term] = w
+		queryNormSq += w * w
+	}
+	if queryNormSq == 0 {
+		return nil
+	}
+	queryNorm := math.Sqrt(queryNormSq)
+
+	// Score each document via dot product / (queryNorm * docNorm)
+	type scored struct {
+		docID string
+		score float64
+	}
+	var results []scored
+	for docID, docVec := range b.docTermFreqs {
+		// Category filter
+		if category != "" {
+			if meta, ok := b.docMeta[docID]; ok && meta.category != category {
+				continue
+			}
+		}
+
+		var dot float64
+		for term, qw := range queryVec {
+			if dw, ok := docVec[term]; ok {
+				dot += qw * dw
+			}
+		}
+		if dot <= 0 {
+			continue
+		}
+		docNorm := b.docNorms[docID]
+		if docNorm <= 0 {
+			continue
+		}
+		score := dot / (queryNorm * docNorm)
+		results = append(results, scored{docID: docID, score: score})
+	}
+
+	// Sort descending by score
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].score > results[j].score
+	})
+
+	if topK > 0 && len(results) > topK {
+		results = results[:topK]
+	}
+
+	out := make([]bm25Result, len(results))
+	for i, r := range results {
+		meta := b.docMeta[r.docID]
+		out[i] = bm25Result{
+			docID:     r.docID,
+			path:      meta.path,
+			startLine: meta.startLine,
+			endLine:   meta.endLine,
+			category:  meta.category,
+			content:   meta.content,
+			score:     r.score,
+		}
+	}
+	return out
+}

--- a/pkg/memory/bm25_test.go
+++ b/pkg/memory/bm25_test.go
@@ -1,0 +1,267 @@
+package memory
+
+import (
+	"math"
+	"testing"
+)
+
+func TestBm25Tokenize_Basic(t *testing.T) {
+	t.Parallel()
+	tokens := bm25Tokenize("Hello, World! This is a test.")
+	expected := []string{"hello", "world", "this", "is", "a", "test"}
+	if len(tokens) != len(expected) {
+		t.Fatalf("expected %d tokens, got %d: %v", len(expected), len(tokens), tokens)
+	}
+	for i, tok := range tokens {
+		if tok != expected[i] {
+			t.Errorf("token %d: expected %q, got %q", i, expected[i], tok)
+		}
+	}
+}
+
+func TestBm25Tokenize_MixedAlphanumeric(t *testing.T) {
+	t.Parallel()
+	tokens := bm25Tokenize("DDR5 64GB SO-DIMM 5600MHz")
+	expected := []string{"ddr5", "64gb", "so", "dimm", "5600mhz"}
+	if len(tokens) != len(expected) {
+		t.Fatalf("expected %d tokens, got %d: %v", len(expected), len(tokens), tokens)
+	}
+	for i, tok := range tokens {
+		if tok != expected[i] {
+			t.Errorf("token %d: expected %q, got %q", i, expected[i], tok)
+		}
+	}
+}
+
+func TestBm25Tokenize_Empty(t *testing.T) {
+	t.Parallel()
+	tokens := bm25Tokenize("")
+	if len(tokens) != 0 {
+		t.Errorf("expected 0 tokens, got %d", len(tokens))
+	}
+}
+
+func TestBm25Tokenize_Lowercase(t *testing.T) {
+	t.Parallel()
+	tokens := bm25Tokenize("FIND Best PRICES")
+	expected := []string{"find", "best", "prices"}
+	if len(tokens) != len(expected) {
+		t.Fatalf("expected %d tokens, got %d: %v", len(expected), len(tokens), tokens)
+	}
+	for i, tok := range tokens {
+		if tok != expected[i] {
+			t.Errorf("token %d: expected %q, got %q", i, expected[i], tok)
+		}
+	}
+}
+
+func TestBuildBM25_Empty(t *testing.T) {
+	t.Parallel()
+	idx := buildBM25(nil)
+	if idx != nil {
+		t.Error("expected nil index for empty input")
+	}
+}
+
+func TestBuildBM25_SingleDoc(t *testing.T) {
+	t.Parallel()
+	docs := []bm25InputDoc{
+		{ID: "1", Content: "find product prices online", Path: "test.md", Category: "guidance"},
+	}
+	idx := buildBM25(docs)
+	if idx == nil {
+		t.Fatal("expected non-nil index")
+	}
+	if idx.totalDocs != 1 {
+		t.Errorf("expected 1 doc, got %d", idx.totalDocs)
+	}
+}
+
+func TestBM25Search_BasicMatch(t *testing.T) {
+	t.Parallel()
+	docs := []bm25InputDoc{
+		{ID: "1", Content: "Web Research and Information Gathering. Find the best price for a product using web search API.", Path: "guidance/web-research.md", StartLine: 1, EndLine: 5, Category: "guidance"},
+		{ID: "2", Content: "Memory Usage. How to save and recall information from memory.", Path: "guidance/memory-usage.md", StartLine: 1, EndLine: 5, Category: "guidance"},
+		{ID: "3", Content: "Job Scheduling. Create scheduled jobs that run automatically.", Path: "guidance/job-scheduling.md", StartLine: 1, EndLine: 5, Category: "guidance"},
+	}
+	idx := buildBM25(docs)
+
+	results := idx.search("find best prices product", 3, "")
+	if len(results) == 0 {
+		t.Fatal("expected at least one result")
+	}
+	if results[0].path != "guidance/web-research.md" {
+		t.Errorf("expected web-research.md as top result, got %q", results[0].path)
+	}
+	if results[0].score <= 0 {
+		t.Error("expected positive score")
+	}
+}
+
+func TestBM25Search_CategoryFilter(t *testing.T) {
+	t.Parallel()
+	docs := []bm25InputDoc{
+		{ID: "1", Content: "find product prices online shopping", Path: "guidance/web-research.md", Category: "guidance"},
+		{ID: "2", Content: "find product prices shopping list", Path: "projects/shopping.md", Category: "knowledge"},
+	}
+	idx := buildBM25(docs)
+
+	// Search with category filter — should only return guidance
+	results := idx.search("find product prices", 10, "guidance")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result with category filter, got %d", len(results))
+	}
+	if results[0].category != "guidance" {
+		t.Errorf("expected guidance category, got %q", results[0].category)
+	}
+
+	// Search without filter — should return both
+	results = idx.search("find product prices", 10, "")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results without filter, got %d", len(results))
+	}
+}
+
+func TestBM25Search_NoMatch(t *testing.T) {
+	t.Parallel()
+	docs := []bm25InputDoc{
+		{ID: "1", Content: "browser automation click navigate", Path: "guidance/browser.md", Category: "guidance"},
+	}
+	idx := buildBM25(docs)
+
+	results := idx.search("quantum physics equations", 10, "")
+	if len(results) != 0 {
+		t.Errorf("expected no results for unrelated query, got %d", len(results))
+	}
+}
+
+func TestBM25Search_TopK(t *testing.T) {
+	t.Parallel()
+	docs := []bm25InputDoc{
+		{ID: "1", Content: "price comparison shopping", Path: "a.md", Category: "knowledge"},
+		{ID: "2", Content: "price deals discount", Path: "b.md", Category: "knowledge"},
+		{ID: "3", Content: "price value money", Path: "c.md", Category: "knowledge"},
+	}
+	idx := buildBM25(docs)
+
+	results := idx.search("price", 2, "")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (topK=2), got %d", len(results))
+	}
+}
+
+func TestBM25Search_NilIndex(t *testing.T) {
+	t.Parallel()
+	var idx *bm25Index
+	results := idx.search("anything", 10, "")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results from nil index, got %d", len(results))
+	}
+}
+
+func TestBM25Search_EmptyQuery(t *testing.T) {
+	t.Parallel()
+	docs := []bm25InputDoc{
+		{ID: "1", Content: "some content", Path: "a.md", Category: "knowledge"},
+	}
+	idx := buildBM25(docs)
+
+	results := idx.search("", 10, "")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for empty query, got %d", len(results))
+	}
+}
+
+func TestBM25Search_ScoresNormalized(t *testing.T) {
+	t.Parallel()
+	docs := []bm25InputDoc{
+		{ID: "1", Content: "find the best prices for products online", Path: "a.md", Category: "guidance"},
+	}
+	idx := buildBM25(docs)
+
+	results := idx.search("find best prices products", 10, "")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	// BM25 cosine similarity should be between 0 and 1
+	if results[0].score < 0 || results[0].score > 1 {
+		t.Errorf("expected score in [0,1], got %f", results[0].score)
+	}
+}
+
+func TestBM25Search_MetadataPreserved(t *testing.T) {
+	t.Parallel()
+	docs := []bm25InputDoc{
+		{ID: "doc1", Content: "price comparison tool", Path: "guidance/web-research.md", StartLine: 10, EndLine: 20, Category: "guidance"},
+	}
+	idx := buildBM25(docs)
+
+	results := idx.search("price comparison", 10, "")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.docID != "doc1" {
+		t.Errorf("expected docID doc1, got %q", r.docID)
+	}
+	if r.path != "guidance/web-research.md" {
+		t.Errorf("expected path guidance/web-research.md, got %q", r.path)
+	}
+	if r.startLine != 10 {
+		t.Errorf("expected startLine 10, got %d", r.startLine)
+	}
+	if r.endLine != 20 {
+		t.Errorf("expected endLine 20, got %d", r.endLine)
+	}
+	if r.category != "guidance" {
+		t.Errorf("expected category guidance, got %q", r.category)
+	}
+	if r.content != "price comparison tool" {
+		t.Errorf("expected content preserved, got %q", r.content)
+	}
+}
+
+func TestBM25Search_DiluteQueryStillFinds(t *testing.T) {
+	// This is the core scenario: a query dominated by product specs
+	// should still find guidance about price research via keyword overlap.
+	t.Parallel()
+	docs := []bm25InputDoc{
+		{
+			ID:       "web-research-1",
+			Content:  "Web Research and Information Gathering. Find the best price for a product using web search API. Compare prices across retailers like Amazon, Newegg, B&H. Do NOT use browser agents.",
+			Path:     "guidance/web-research.md",
+			Category: "guidance",
+		},
+		{
+			ID:       "memory-usage-1",
+			Content:  "Memory Usage. How to save and recall information from memory. Use memory_save to store durable facts.",
+			Path:     "guidance/memory-usage.md",
+			Category: "guidance",
+		},
+		{
+			ID:       "browser-1",
+			Content:  "Browser Automation. Navigate, click, type, and observe web pages using browser tools.",
+			Path:     "guidance/browser-automation.md",
+			Category: "guidance",
+		},
+	}
+	idx := buildBM25(docs)
+
+	// Query dominated by product specs, but contains "prices" and "find"
+	results := idx.search("Can you find for me the best prices for the Kingston FURY Impact 64GB DDR5 SO-DIMM DDR5 5600 Laptop Memory Provide the links to the product", 3, "")
+	if len(results) == 0 {
+		t.Fatal("expected at least one result for diluted query")
+	}
+	if results[0].path != "guidance/web-research.md" {
+		t.Errorf("expected web-research.md as top result, got %q", results[0].path)
+	}
+}
+
+func TestMaxRRFScore(t *testing.T) {
+	t.Parallel()
+	// Verify the constant matches the formula
+	expected := 2.0 / (60.0 + 1.0)
+	if math.Abs(maxRRFScore-expected) > 1e-10 {
+		t.Errorf("maxRRFScore = %f, expected %f", maxRRFScore, expected)
+	}
+}

--- a/pkg/memory/indexer.go
+++ b/pkg/memory/indexer.go
@@ -133,6 +133,9 @@ func (idx *Indexer) IndexAll(ctx context.Context) error {
 	// Persist the file index so the next startup can skip unchanged files.
 	idx.saveFileIndex()
 
+	// Rebuild the BM25 keyword index from all tracked documents.
+	idx.store.RebuildBM25()
+
 	return nil
 }
 
@@ -145,6 +148,8 @@ func (idx *Indexer) IndexFile(ctx context.Context, relPath string) error {
 	}
 	// Persist after individual file changes (e.g. from file watcher).
 	idx.saveFileIndex()
+	// Rebuild BM25 to include the new/changed content.
+	idx.store.RebuildBM25()
 	return nil
 }
 

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -15,6 +16,8 @@ type Store struct {
 	collection *chromem.Collection
 	config     *StoreConfig
 	indexer    *Indexer
+	bm25       *bm25Index     // keyword search index (rebuilt after indexing)
+	bm25Docs   []bm25InputDoc // retained for incremental BM25 rebuilds
 
 	mu sync.RWMutex
 }
@@ -141,6 +144,7 @@ func (s *Store) Search(ctx context.Context, query string, maxResults int, minSco
 
 // AddDocuments adds chunks to the collection. Each chunk is stored as a
 // chromem-go Document with metadata for path, startLine, endLine.
+// Also updates the BM25 keyword index.
 func (s *Store) AddDocuments(ctx context.Context, chunks []Chunk) error {
 	if len(chunks) == 0 {
 		return nil
@@ -158,6 +162,15 @@ func (s *Store) AddDocuments(ctx context.Context, chunks []Chunk) error {
 				"category":  c.Category,
 			},
 		}
+		// Track for BM25
+		s.bm25Docs = append(s.bm25Docs, bm25InputDoc{
+			ID:        c.ID,
+			Content:   c.Text,
+			Path:      c.Path,
+			StartLine: c.StartLine,
+			EndLine:   c.EndLine,
+			Category:  c.Category,
+		})
 	}
 
 	// Use concurrency of 4 for embedding
@@ -165,7 +178,17 @@ func (s *Store) AddDocuments(ctx context.Context, chunks []Chunk) error {
 }
 
 // DeleteByPath removes all chunks for a given file path.
+// Also removes the corresponding entries from the BM25 index data.
 func (s *Store) DeleteByPath(ctx context.Context, path string) error {
+	// Remove from BM25 tracking
+	filtered := s.bm25Docs[:0]
+	for _, d := range s.bm25Docs {
+		if d.Path != path {
+			filtered = append(filtered, d)
+		}
+	}
+	s.bm25Docs = filtered
+
 	return s.collection.Delete(ctx, map[string]string{"path": path}, nil)
 }
 
@@ -261,4 +284,165 @@ func (s *Store) ReindexFile(ctx context.Context, relPath string) error {
 // interface completeness.
 func (s *Store) Close() error {
 	return nil
+}
+
+// RebuildBM25 rebuilds the BM25 keyword index from the tracked documents.
+// This should be called after IndexAll or IndexFile completes.
+func (s *Store) RebuildBM25() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bm25 = buildBM25(s.bm25Docs)
+}
+
+// rrfK is the constant for Reciprocal Rank Fusion (Cormack et al. 2009).
+const rrfK = 60.0
+
+// maxRRFScore is the maximum possible RRF score with 2 retrieval methods
+// and k=60: 2 × 1/(60+1) ≈ 0.03279. Used to normalize scores to 0-1.
+var maxRRFScore = 2.0 / (rrfK + 1.0)
+
+// SearchHybrid performs hybrid search: vector (semantic) + BM25 (keyword),
+// fused with Reciprocal Rank Fusion. This solves the "query dilution" problem
+// where specific terms (product specs, model numbers) shift the dense embedding
+// away from relevant documents, but keyword matching on shared terms still works.
+//
+// Scores are normalized to 0-1 range (1.0 = rank 1 in both methods).
+func (s *Store) SearchHybrid(ctx context.Context, query string, maxResults int,
+	minScore float64) ([]SearchResult, error) {
+
+	return s.searchHybrid(ctx, query, maxResults, minScore, "")
+}
+
+// SearchHybridByCategory performs hybrid search filtered to a specific category.
+func (s *Store) SearchHybridByCategory(ctx context.Context, query string, maxResults int,
+	minScore float64, category string) ([]SearchResult, error) {
+
+	return s.searchHybrid(ctx, query, maxResults, minScore, category)
+}
+
+// searchHybrid is the internal implementation of hybrid search.
+func (s *Store) searchHybrid(ctx context.Context, query string, maxResults int,
+	minScore float64, category string) ([]SearchResult, error) {
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults <= 0 {
+		maxResults = s.config.MaxResults
+	}
+	if minScore <= 0 {
+		minScore = s.config.MinScore
+	}
+
+	// --- Vector search ---
+	docCount := s.collection.Count()
+	var vectorResults []chromem.Result
+	if docCount > 0 {
+		candidateK := maxResults * 3
+		if candidateK < 20 {
+			candidateK = 20
+		}
+		if candidateK > docCount {
+			candidateK = docCount
+		}
+
+		var where map[string]string
+		if category != "" {
+			where = map[string]string{"category": category}
+		}
+
+		var err error
+		vectorResults, err = s.collection.Query(ctx, query, candidateK, where, nil)
+		if err != nil {
+			return nil, fmt.Errorf("vector search failed: %w", err)
+		}
+	}
+
+	// --- BM25 keyword search ---
+	candidateK := maxResults * 3
+	if candidateK < 20 {
+		candidateK = 20
+	}
+	bm25Results := s.bm25.search(query, candidateK, category)
+
+	// --- Reciprocal Rank Fusion ---
+	type fusedEntry struct {
+		path      string
+		startLine int
+		endLine   int
+		category  string
+		snippet   string
+		rrfScore  float64
+	}
+	fused := make(map[string]*fusedEntry) // keyed by chunkID (path:startLine:endLine)
+
+	// Helper to build a stable key for deduplication
+	chunkKey := func(path string, startLine, endLine int) string {
+		return fmt.Sprintf("%s:%d:%d", path, startLine, endLine)
+	}
+
+	// Add vector results
+	for rank, r := range vectorResults {
+		startLine, _ := strconv.Atoi(r.Metadata["startLine"])
+		endLine, _ := strconv.Atoi(r.Metadata["endLine"])
+		key := chunkKey(r.Metadata["path"], startLine, endLine)
+
+		e, ok := fused[key]
+		if !ok {
+			e = &fusedEntry{
+				path:      r.Metadata["path"],
+				startLine: startLine,
+				endLine:   endLine,
+				category:  r.Metadata["category"],
+				snippet:   r.Content,
+			}
+			fused[key] = e
+		}
+		e.rrfScore += 1.0 / (rrfK + float64(rank+1))
+	}
+
+	// Add BM25 results
+	for rank, r := range bm25Results {
+		key := chunkKey(r.path, r.startLine, r.endLine)
+
+		e, ok := fused[key]
+		if !ok {
+			e = &fusedEntry{
+				path:      r.path,
+				startLine: r.startLine,
+				endLine:   r.endLine,
+				category:  r.category,
+				snippet:   r.content,
+			}
+			fused[key] = e
+		}
+		e.rrfScore += 1.0 / (rrfK + float64(rank+1))
+	}
+
+	// Collect, normalize, sort, and filter
+	results := make([]SearchResult, 0, len(fused))
+	for _, e := range fused {
+		normalizedScore := e.rrfScore / maxRRFScore
+		if normalizedScore < minScore {
+			continue
+		}
+		results = append(results, SearchResult{
+			Path:      e.path,
+			StartLine: e.startLine,
+			EndLine:   e.endLine,
+			Score:     normalizedScore,
+			Snippet:   e.snippet,
+			Category:  e.category,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	if len(results) > maxResults {
+		results = results[:maxResults]
+	}
+
+	return results, nil
 }


### PR DESCRIPTION
## Summary

- Adds BM25 keyword search alongside existing vector (semantic) search in the memory store, fused with Reciprocal Rank Fusion (RRF, k=60)
- Fixes the "query dilution" problem where product specs/proper nouns in user queries shifted dense embeddings away from relevant guidance docs (e.g., `guidance/web-research.md` scored 0.291 with pure vector search, now scores 0.500 with hybrid)
- Verified end-to-end: session d183669a shows the agent correctly receiving the web-research guidance and using 2 parallel `tavily_search` calls instead of launching 3 browser sub-agents

## Changes

| File | Description |
|------|-------------|
| `pkg/memory/bm25.go` | **New**: BM25 inverted index (TF-IDF + cosine similarity, category filter) |
| `pkg/memory/bm25_test.go` | **New**: 16 unit tests including query dilution regression test |
| `pkg/memory/store.go` | `SearchHybrid()`, `SearchHybridByCategory()` with RRF normalization (0-1 range) |
| `pkg/memory/indexer.go` | `RebuildBM25()` calls after `IndexAll` and `IndexFile` |
| `pkg/launcher/chat_factory.go` | Switch `Search` → `SearchHybrid`, `SearchByCategory` → `SearchHybridByCategory` |
| `cmd/astonish/memory.go` | Switch CLI `memory search` to `SearchHybrid` |

## How it works

1. Both vector and BM25 retrieve `maxResults * 3` candidates (min 20)
2. Each result gets an RRF score: `1/(k + rank)` from each method
3. Scores are summed and normalized: `rrfScore / maxRRFScore` where `maxRRFScore = 2/(k+1)`
4. A result at rank 1 in both methods = 1.0; rank 1 in one method only ≈ 0.5
5. Existing `minScore` threshold applies to the normalized score

## Testing

- All 16 BM25 unit tests pass
- Full memory package test suite passes (60+ tests)
- `golangci-lint` clean
- Production verified in session d183669a with the exact query that originally triggered the investigation