### PR TITLE
fix: CloakBrowser container support — proper deps, diagnostics, and single-tab startup

### DIFF
--- a/cmd/astonish/browser_setup.go
+++ b/cmd/astonish/browser_setup.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -78,7 +77,7 @@ func browserStatusDescription(engine string, cfg *config.AppConfig) string {
 	case "default":
 		return "Currently using: Default Chromium (auto-downloaded)"
 	case "cloakbrowser":
-		desc := fmt.Sprintf("Currently using: CloakBrowser at %s", cfg.Browser.ChromePath)
+		desc := "Currently using: CloakBrowser"
 		if cfg.Browser.FingerprintPlatform != "" {
 			desc += fmt.Sprintf(" (platform: %s)", cfg.Browser.FingerprintPlatform)
 		}
@@ -121,154 +120,17 @@ func configureBrowserDefault(cfg *config.AppConfig) error {
 	return nil
 }
 
-// configureBrowserCloak sets up CloakBrowser with dependency validation,
-// automatic installation, and fingerprint configuration.
+// configureBrowserCloak configures CloakBrowser (anti-detect Chromium with
+// stealth patches) and prompts for fingerprint settings. The actual
+// installation of CloakBrowser happens inside the sandbox container during
+// template creation — this function only saves the config values that tell
+// the sandbox builder to use the CloakBrowser engine instead of default
+// Chromium.
 func configureBrowserCloak(cfg *config.AppConfig) error {
-	clearScreen()
-	fmt.Println("  Checking dependencies...")
-	fmt.Println()
-
-	// 1. Check OS (CloakBrowser only supports Linux and macOS)
-	if runtime.GOOS == "windows" {
-		printBrowserError("CloakBrowser does not support Windows. Use the Default engine or a Custom path.")
-		return fmt.Errorf("unsupported platform: windows")
-	}
-
-	// 2. Check Python 3
-	python3, err := exec.LookPath("python3")
-	if err != nil {
-		printBrowserCheck(false, "Python 3", "")
-		fmt.Println()
-		printBrowserError("Python 3 is required to install CloakBrowser.\n  Install it with: apt install python3")
-		return fmt.Errorf("python3 not found")
-	}
-	printBrowserCheck(true, "Python 3", "")
-
-	// 3. Check pip3
-	_, err = exec.LookPath("pip3")
-	if err != nil {
-		printBrowserCheck(false, "pip3", "")
-		fmt.Println()
-
-		var installPip bool
-		err = huh.NewForm(
-			huh.NewGroup(
-				huh.NewConfirm().
-					Title("pip3 is required but not found").
-					Description("Install python3-pip automatically?").
-					Affirmative("Yes, install").
-					Negative("No, abort").
-					Value(&installPip),
-			),
-		).Run()
-		if err != nil {
-			return err
-		}
-		if !installPip {
-			printBrowserError("pip3 is required. Install it with: apt install python3-pip")
-			return fmt.Errorf("pip3 not found")
-		}
-
-		fmt.Println("  Installing pip3...")
-		cmd := exec.Command("apt-get", "install", "-y", "-qq", "python3-pip")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			printBrowserError(fmt.Sprintf("Failed to install pip3: %v\n  Install manually with: apt install python3-pip", err))
-			return fmt.Errorf("failed to install pip3: %w", err)
-		}
-		printBrowserCheck(true, "pip3", "installed")
-	} else {
-		printBrowserCheck(true, "pip3", "")
-	}
-
-	// 4. Check Xvfb
-	_, err = exec.LookPath("Xvfb")
-	if err != nil {
-		// Also try lowercase
-		_, err = exec.LookPath("xvfb")
-	}
-	if err != nil {
-		printBrowserCheck(false, "Xvfb", "")
-		fmt.Println()
-
-		var installXvfb bool
-		err = huh.NewForm(
-			huh.NewGroup(
-				huh.NewConfirm().
-					Title("Xvfb is required for headed stealth mode").
-					Description("Without Xvfb, the browser falls back to headless mode which is easier to detect.\nInstall Xvfb automatically?").
-					Affirmative("Yes, install").
-					Negative("No, abort").
-					Value(&installXvfb),
-			),
-		).Run()
-		if err != nil {
-			return err
-		}
-		if !installXvfb {
-			printBrowserError("Xvfb is required for CloakBrowser stealth mode.\n  Install it with: apt install xvfb")
-			return fmt.Errorf("xvfb not found")
-		}
-
-		fmt.Println("  Installing Xvfb...")
-		cmd := exec.Command("apt-get", "install", "-y", "-qq", "xvfb")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			printBrowserError(fmt.Sprintf("Failed to install Xvfb: %v\n  Install manually with: apt install xvfb", err))
-			return fmt.Errorf("failed to install xvfb: %w", err)
-		}
-		printBrowserCheck(true, "Xvfb", "installed")
-	} else {
-		printBrowserCheck(true, "Xvfb", "")
-	}
-
-	// 5. Check/install CloakBrowser
-	binaryPath := findCloakBrowserBinary()
-	if binaryPath == "" {
-		printBrowserCheck(false, "CloakBrowser", "")
-		fmt.Println()
-		fmt.Println("  Installing CloakBrowser (this may take a moment)...")
-
-		// Install the Python package
-		cmd := exec.Command("pip3", "install", "--break-system-packages", "cloakbrowser")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			printBrowserError(fmt.Sprintf("Failed to install CloakBrowser package: %v", err))
-			return fmt.Errorf("failed to install cloakbrowser: %w", err)
-		}
-
-		// Download the binary
-		fmt.Println("  Downloading CloakBrowser Chromium binary...")
-		out, err := exec.Command(python3, "-c",
-			"import cloakbrowser; print(cloakbrowser.ensure_binary())").CombinedOutput()
-		if err != nil {
-			printBrowserError(fmt.Sprintf("Failed to download CloakBrowser binary: %v\n  Output: %s", err, strings.TrimSpace(string(out))))
-			return fmt.Errorf("failed to download cloakbrowser binary: %w", err)
-		}
-
-		binaryPath = strings.TrimSpace(string(out))
-		if binaryPath == "" || !fileExists(binaryPath) {
-			printBrowserError("CloakBrowser binary not found after download")
-			return fmt.Errorf("cloakbrowser binary not found")
-		}
-	}
-
-	// Verify the binary works
-	verOut, err := exec.Command(binaryPath, "--version").CombinedOutput()
-	if err != nil {
-		printBrowserError(fmt.Sprintf("CloakBrowser binary failed to run: %v", err))
-		return fmt.Errorf("cloakbrowser binary failed: %w", err)
-	}
-	version := strings.TrimSpace(string(verOut))
-	printBrowserCheck(true, "CloakBrowser", version)
-
-	// 6. Fingerprint platform selection
+	// 1. Fingerprint platform selection
 	var platform string
 	clearScreen()
-	err = huh.NewForm(
+	err := huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Fingerprint platform").
@@ -285,7 +147,7 @@ func configureBrowserCloak(cfg *config.AppConfig) error {
 		return err
 	}
 
-	// 7. Fingerprint seed
+	// 2. Fingerprint seed
 	var seedChoice string
 	clearScreen()
 	err = huh.NewForm(
@@ -325,16 +187,20 @@ func configureBrowserCloak(cfg *config.AppConfig) error {
 		}
 	}
 
-	// 8. Save config
-	cfg.Browser.ChromePath = binaryPath
+	// 3. Save config — use "cloakbrowser" as the ChromePath sentinel so
+	// DetectBrowserEngine() identifies this as the CloakBrowser engine.
+	// The actual binary is installed inside the sandbox container during
+	// template creation (see BrowserContainerInstallCommands).
+	cfg.Browser.ChromePath = "cloakbrowser"
 	cfg.Browser.FingerprintSeed = seed
 	cfg.Browser.FingerprintPlatform = platform
+	cfg.Browser.RemoteCDPURL = ""
 
 	if err := config.SaveAppConfig(cfg); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
-	printBrowserSuccess(fmt.Sprintf("Browser configured to use CloakBrowser!\n  Engine: CloakBrowser (%s)\n  Platform: %s\n  Fingerprint seed: %s", version, platform, seed))
+	printBrowserSuccess(fmt.Sprintf("Browser configured to use CloakBrowser!\n  Platform: %s\n  Fingerprint seed: %s\n\n  CloakBrowser will be installed in the sandbox container.", platform, seed))
 	return nil
 }
 
@@ -536,47 +402,6 @@ func discoverCDPEndpoint(endpoint string) (wsURL string, version string, err err
 	}
 
 	return wsURL, result.Browser, nil
-}
-
-// findCloakBrowserBinary looks for an existing CloakBrowser installation.
-// First checks via Python (reliable, version-independent), then falls back
-// to scanning the known cache directory.
-func findCloakBrowserBinary() string {
-	// Try Python resolution first (handles version changes gracefully)
-	python3, err := exec.LookPath("python3")
-	if err == nil {
-		out, err := exec.Command(python3, "-c",
-			"from cloakbrowser.config import get_binary_path; print(get_binary_path())").CombinedOutput()
-		if err == nil {
-			path := strings.TrimSpace(string(out))
-			if path != "" && fileExists(path) {
-				return path
-			}
-		}
-	}
-
-	// Fallback: scan the known cache directory for any chromium-*/chrome
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	cacheDir := filepath.Join(home, ".cloakbrowser")
-	entries, err := os.ReadDir(cacheDir)
-	if err != nil {
-		return ""
-	}
-
-	// Pick the latest version directory (sorted lexicographically)
-	var latest string
-	for _, e := range entries {
-		if e.IsDir() && strings.HasPrefix(e.Name(), "chromium-") {
-			candidate := filepath.Join(cacheDir, e.Name(), "chrome")
-			if fileExists(candidate) {
-				latest = candidate
-			}
-		}
-	}
-	return latest
 }
 
 // generateFingerprintSeed creates a random numeric seed between 10000 and 99999.

--- a/pkg/browser/manager.go
+++ b/pkg/browser/manager.go
@@ -563,6 +563,23 @@ func (m *Manager) resolveCDPURL(containerName, ip string) (string, error) {
 //
 // Must be called with m.mu held.
 func (m *Manager) launchInContainer() (*rod.Browser, error) {
+	b, err := m.launchInContainerInner()
+	if err != nil {
+		return nil, err
+	}
+
+	// Close extra tabs that Chromium may have opened on startup (e.g.
+	// first-run welcome page, session restore, default homepage). We want
+	// to start with a single about:blank tab so the AI agent controls
+	// exactly what is open. This is only done for container-launched
+	// browsers — not for connectRemote() with external anti-detect browsers
+	// whose tab state we should not touch.
+	m.closeExtraTabs(b)
+
+	return b, nil
+}
+
+func (m *Manager) launchInContainerInner() (*rod.Browser, error) {
 	// If RemoteCDPURL is already set (by a previous call or external setup),
 	// resolve it to the full debugger URL if it's a bare host:port.
 	if m.config.RemoteCDPURL != "" {
@@ -925,6 +942,23 @@ func (m *Manager) CurrentPage() (*rod.Page, error) {
 	m.activePg = pg
 	m.ensurePageState(pg)
 	return pg, nil
+}
+
+// closeExtraTabs closes all but one tab in the browser. Chromium may open
+// extra tabs on startup (first-run welcome, session restore, default homepage).
+// We keep the first tab (typically about:blank) and close the rest so the
+// agent starts with a clean, single-tab browser.
+// Must be called with m.mu held.
+func (m *Manager) closeExtraTabs(b *rod.Browser) {
+	pages, err := b.Pages()
+	if err != nil || len(pages) <= 1 {
+		return
+	}
+	// Keep the first page, close the rest.
+	for _, pg := range pages[1:] {
+		_ = pg.Close()
+	}
+	m.logger.Printf("Closed %d extra startup tab(s)", len(pages)-1)
 }
 
 // SetActivePage sets a specific page as the active page.

--- a/pkg/sandbox/browser_container.go
+++ b/pkg/sandbox/browser_container.go
@@ -100,14 +100,36 @@ func BrowserContainerInstallCommands(engine, arch string) [][]string {
 	case "cloakbrowser":
 		// CloakBrowser needs python3, pip3, xvfb (for headed stealth mode),
 		// plus all the shared X11/font deps that Chromium requires.
+		// Unlike the "default" engine where `apt install chromium` pulls in
+		// transitive deps automatically, CloakBrowser is a standalone binary
+		// download — we must install every shared library it links against.
 		cmds = append(cmds, []string{"apt-get", "install", "-y",
 			// CloakBrowser runtime deps
 			"python3", "python3-pip", "xvfb",
-			// Chromium shared deps (CloakBrowser is a patched Chromium)
+			// Chromium shared deps (CloakBrowser is a patched Chromium).
+			// These must be listed explicitly because the binary is not
+			// installed via apt and has no automatic dependency resolution.
 			"fonts-liberation", "fonts-noto-color-emoji",
 			"xdg-utils", "libnss3", "libatk-bridge2.0-0",
 			"libx11-xcb1", "libxcomposite1", "libxrandr2",
 			"libgbm1", "libasound2t64",
+			"libcups2",            // CUPS printing (required by Chromium's print subsystem)
+			"libpango-1.0-0",      // text layout and rendering
+			"libcairo2",           // 2D graphics
+			"libdbus-1-3",         // D-Bus IPC
+			"libdrm2",             // Direct Rendering Manager
+			"libexpat1",           // XML parsing
+			"libxdamage1",         // X11 damage extension
+			"libxext6",            // X11 extensions
+			"libxfixes3",          // X11 fixes extension
+			"libxkbcommon0",       // keyboard handling
+			"libatspi2.0-0",       // accessibility
+			"libvulkan1",          // Vulkan graphics (optional but avoids warnings)
+			"libxcb-dri3-0",       // XCB DRI3 extension (GPU buffer sharing)
+			"libatk1.0-0",         // ATK accessibility toolkit (base, needed alongside bridge)
+			"libgtk-3-0",          // GTK3 (Chromium UI toolkit dependency)
+			"libgdk-pixbuf-2.0-0", // GDK-Pixbuf image loading
+			"libnspr4",            // Netscape Portable Runtime (NSS dependency)
 			// KasmVNC dependencies
 			"libjpeg-turbo8", "libwebp-dev", "libssl3",
 			"xfonts-base", "xfonts-75dpi", "xfonts-100dpi",
@@ -530,7 +552,9 @@ if [ -z "$BROWSER_BIN" ] || [ ! -f "$BROWSER_BIN" ]; then
   exit 1
 fi
 export DISPLAY=%s
-# Launch CloakBrowser as the browser user on the Xvnc display
+BROWSER_LOG=/tmp/cloakbrowser.log
+# Launch CloakBrowser as the browser user on the Xvnc display.
+# Redirect stdout+stderr to a log file so we can diagnose crashes.
 runuser -l browser -c "%sDISPLAY=%s $BROWSER_BIN \
   --no-sandbox \
   --test-type \
@@ -542,11 +566,47 @@ runuser -l browser -c "%sDISPLAY=%s $BROWSER_BIN \
   --disable-background-timer-throttling \
   --disable-backgrounding-occluded-windows \
   --disable-renderer-backgrounding \
-  --disable-blink-features=AutomationControlled%s%s \
-  about:blank &"
-sleep 1
+  --disable-blink-features=AutomationControlled \
+  --no-first-run \
+  --no-default-browser-check \
+  --noerrdialogs \
+  --disable-features=TranslateUI%s%s \
+  about:blank >$BROWSER_LOG 2>&1 &"
+sleep 2
+# Verify the browser process started by checking if any chrome/chromium
+# process is running. If not, the binary crashed on startup — report the
+# log so the error propagates to the user instead of a generic CDP timeout.
+if ! pgrep -u browser -f 'chrome|chromium' >/dev/null 2>&1; then
+  echo "CloakBrowser process died on startup. Binary: $BROWSER_BIN" >&2
+  echo "--- browser log ---" >&2
+  cat $BROWSER_LOG >&2 2>/dev/null
+  echo "--- end log ---" >&2
+  exit 1
+fi
+# Verify the DevTools port is bound. CloakBrowser may start the main process
+# but fail to initialize the DevTools server (e.g. if the binary does not
+# support --remote-debugging-port). Wait up to 5 seconds for port %d.
+CDP_READY=0
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if ss -tln 2>/dev/null | grep -q ':%d '; then
+    CDP_READY=1
+    break
+  fi
+  sleep 0.5
+done
+if [ "$CDP_READY" = "0" ]; then
+  echo "CloakBrowser started but DevTools port %d is not listening after 5s." >&2
+  echo "Binary: $BROWSER_BIN" >&2
+  echo "Listening ports:" >&2
+  ss -tln >&2 2>/dev/null
+  echo "--- browser log ---" >&2
+  cat $BROWSER_LOG >&2 2>/dev/null
+  echo "--- end log ---" >&2
+  exit 1
+fi
 # Bridge CDP port to all interfaces so the host can connect
-%s`, display, ldPreload, display, internalCDPPort, width, height, BrowserProfileMountPath, fingerprintFlags, proxyFlag, socatBridge)
+%s`, display, ldPreload, display, internalCDPPort, width, height, BrowserProfileMountPath, fingerprintFlags, proxyFlag,
+			internalCDPPort, internalCDPPort, internalCDPPort, socatBridge)
 
 	default: // "default" — headed Google Chrome (/usr/bin/chromium via symlink)
 		proxyFlag := ""
@@ -567,7 +627,11 @@ sleep 1
 				"--disable-background-timer-throttling "+
 				"--disable-backgrounding-occluded-windows "+
 				"--disable-renderer-backgrounding "+
-				"--disable-blink-features=AutomationControlled%s "+
+				"--disable-blink-features=AutomationControlled "+
+				"--no-first-run "+
+				"--no-default-browser-check "+
+				"--noerrdialogs "+
+				"--disable-features=TranslateUI%s "+
 				"about:blank &\"\nsleep 1\n"+
 				"# Bridge CDP port to all interfaces so the host can connect\n%s",
 			display, ldPreload, display, internalCDPPort, width, height, BrowserProfileMountPath, proxyFlag, socatBridge,


### PR DESCRIPTION
## Summary

- **Moved CloakBrowser installation entirely into the sandbox container**, removing all host-side installation code (Python3, pip3, Xvfb checks/installs, binary download) from the setup wizard. The wizard now only saves config values; the container template handles installation.

- **Added 16 missing shared library packages** to the CloakBrowser container install list (`libcups2`, `libpango-1.0-0`, `libcairo2`, `libgtk-3-0`, `libgdk-pixbuf-2.0-0`, `libnspr4`, `libxkbcommon0`, `libxdamage1`, `libatspi2.0-0`, `libvulkan1`, `libxcb-dri3-0`, `libatk1.0-0`, etc.) that the standalone Chromium binary requires but apt cannot auto-resolve since CloakBrowser is installed via pip.

- **Added startup diagnostics** to the CloakBrowser launch script: stderr log capture to `/tmp/cloakbrowser.log`, process liveness check via `pgrep`, and CDP port binding verification with a 5-second retry loop — crashes now surface the actual error instead of a generic "CDP timeout after 15s".

- **Fixed extra tabs on startup** by adding `--no-first-run`, `--no-default-browser-check`, `--noerrdialogs`, and `--disable-features=TranslateUI` flags to both CloakBrowser and default Chromium launch scripts, plus a `closeExtraTabs()` method in the browser manager that closes all but one tab after CDP connection in container mode.

## Files Changed

| File | Change |
|------|--------|
| `cmd/astonish/browser_setup.go` | Rewrote `configureBrowserCloak()` to skip host-side install; removed `findCloakBrowserBinary()`; removed `runtime` import |
| `pkg/sandbox/browser_container.go` | Added 16 shared lib packages to CloakBrowser install list; added diagnostic launch script; added `--no-first-run` and related flags to both engine launch scripts |
| `pkg/browser/manager.go` | Added `closeExtraTabs()` method; called from `launchInContainer()` after CDP connection |

## Testing

- `go build ./...` — passes
- `go test ./...` — all tests pass (including `pkg/browser` and `pkg/sandbox` fresh runs)
- `golangci-lint run` — 0 issues
- Live tested: CloakBrowser launches in container with all deps satisfied on first attempt, only one tab visible