### PR TITLE
feat: per-thread email sessions, config hot-reload, container name sanitization, and CTE decoding fix

### DIFF
--- a/cmd/astonish/sandbox.go
+++ b/cmd/astonish/sandbox.go
@@ -508,8 +508,9 @@ func handleSandboxCreate(templateName, label string) error {
 	// Generate a session ID. If --name is provided, use it directly so
 	// it is easy to identify in `sandbox list`. Otherwise generate one
 	// from the template name and a timestamp.
-	// The session ID must produce valid Incus container names (alphanumeric
-	// and hyphens only) since SessionContainerName uses the first 8 chars.
+	// The session ID must produce valid Incus container names.
+	// SessionContainerName sanitizes the ID (replacing invalid chars with
+	// hyphens) and truncates to 20 chars, so any string is safe.
 	var sessionID string
 	if label != "" {
 		sessionID = label

--- a/cmd/astonish/sessions.go
+++ b/cmd/astonish/sessions.go
@@ -96,11 +96,16 @@ func handleSessionsList() error {
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "ID\tTITLE\tMESSAGES\tUPDATED\tAGE")
+
+	// Compute shortest unique prefix for each session ID
+	allIDs := make([]string, len(metas))
+	for i, m := range metas {
+		allIDs[i] = m.ID
+	}
+	shortIDs := persistentsession.ShortIDs(allIDs)
+
 	for _, m := range metas {
-		id := m.ID
-		if len(id) > 8 {
-			id = id[:8]
-		}
+		id := shortIDs[m.ID]
 		title := m.Title
 		if title == "" {
 			title = "-"
@@ -413,7 +418,8 @@ func resolveSessionID(index *persistentsession.SessionIndex, partial string) (st
 	case 1:
 		return matches[0], nil
 	default:
-		return "", fmt.Errorf("ambiguous session ID %q matches %d sessions", partial, len(matches))
+		sort.Strings(matches)
+		return "", fmt.Errorf("ambiguous session ID %q matches %d sessions:\n  %s", partial, len(matches), strings.Join(matches, "\n  "))
 	}
 }
 

--- a/pkg/api/chat_handlers.go
+++ b/pkg/api/chat_handlers.go
@@ -725,10 +725,7 @@ func handleSlashCommand(ctx context.Context, w io.Writer, flusher http.Flusher, 
 			status += fmt.Sprintf("- Flows: %d saved\n", len(entries))
 		}
 		if sessionID != "" {
-			shortID := sessionID
-			if len(shortID) > 8 {
-				shortID = shortID[:8]
-			}
+			shortID := persistentsession.SafeShortID(sessionID, 16)
 			status += fmt.Sprintf("- Session: `%s`", shortID)
 		}
 		SendSSE(w, flusher, "system", map[string]interface{}{"content": status})

--- a/pkg/channels/channel.go
+++ b/pkg/channels/channel.go
@@ -73,6 +73,7 @@ type MessageHandler func(ctx context.Context, msg InboundMessage) error
 // InboundMessage is a platform-normalized inbound message.
 type InboundMessage struct {
 	ID         string    // Platform message ID
+	MessageID  string    // RFC 2822 Message-ID header (email only, for thread tracking)
 	ChannelID  string    // Channel adapter ID (e.g., "telegram")
 	SenderID   string    // Normalized sender identifier
 	SenderName string    // Human-readable sender name
@@ -117,6 +118,13 @@ type ChannelStatus struct {
 	ConnectedAt  time.Time // When the connection was established
 	Error        string    // Last error message (empty if healthy)
 	MessageCount int64     // Total messages processed since start
+}
+
+// AllowlistUpdater is an optional interface that channels can implement to
+// update their sender allowlist at runtime without requiring a full restart.
+// This is called when config.yaml changes and only the allow_from list differs.
+type AllowlistUpdater interface {
+	UpdateAllowlist(allowFrom []string)
 }
 
 // CommandRefresher is an optional interface that channels can implement to

--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -5,6 +5,7 @@ package email
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"log"
 	"net/mail"
@@ -16,6 +17,7 @@ import (
 	"github.com/schardosin/astonish/pkg/channels"
 	"github.com/schardosin/astonish/pkg/channels/telegram"
 	emailpkg "github.com/schardosin/astonish/pkg/email"
+	"github.com/schardosin/astonish/pkg/session"
 )
 
 // Config holds configuration for the Email channel adapter.
@@ -54,8 +56,14 @@ type EmailChannel struct {
 	// seenIDs tracks Message-IDs we've already processed to avoid duplicates.
 	seenIDs  map[string]bool
 	seenMu   sync.Mutex
+	allowMu  sync.RWMutex
 	allowSet map[string]bool
 	allowAll bool
+
+	// threadIndex maps email Message-IDs to session keys for per-thread sessions.
+	// When set, new emails create new sessions and replies are routed to the
+	// same session as the original thread. When nil, falls back to per-sender routing.
+	threadIndex *session.ThreadIndex
 }
 
 // New creates a new Email channel adapter.
@@ -90,6 +98,14 @@ func New(cfg *Config, logger *log.Logger) *EmailChannel {
 		allowSet: allowSet,
 		allowAll: allowAll,
 	}
+}
+
+// SetThreadIndex injects the thread index for per-thread email sessions.
+// Must be called before Start. When set, new emails create new sessions and
+// replies (identified by In-Reply-To / References) are routed to the existing
+// thread session. Without it, all emails from a sender share one session.
+func (e *EmailChannel) SetThreadIndex(idx *session.ThreadIndex) {
+	e.threadIndex = idx
 }
 
 // ID returns the channel identifier.
@@ -194,6 +210,8 @@ func (e *EmailChannel) Stop(ctx context.Context) error {
 }
 
 // Send delivers an outbound message via email (SMTP).
+// If thread indexing is enabled, the outbound Message-ID is indexed to the
+// session so that user replies to our response chain correctly.
 func (e *EmailChannel) Send(ctx context.Context, target channels.Target, msg channels.OutboundMessage) error {
 	e.mu.RLock()
 	client := e.client
@@ -217,23 +235,37 @@ func (e *EmailChannel) Send(ctx context.Context, target channels.Target, msg cha
 		outgoing.HTML = markdownToEmailHTML(msg.Text)
 	}
 
+	var outboundMessageID string
+	var err error
+
 	// If this is a reply to an inbound message, use Reply for proper threading
 	if msg.ReplyTo != "" {
-		_, err := client.Reply(ctx, msg.ReplyTo, false, outgoing)
+		outboundMessageID, err = client.Reply(ctx, msg.ReplyTo, false, outgoing)
+	} else {
+		outboundMessageID, err = client.Send(ctx, outgoing)
+	}
+
+	if err != nil {
 		return err
 	}
 
-	_, err := client.Send(ctx, outgoing)
-	return err
+	// Index the outbound Message-ID so the user's reply to our response
+	// chains back to the same session. target.ThreadID contains the session key.
+	if e.threadIndex != nil && outboundMessageID != "" && target.ThreadID != "" {
+		if indexErr := e.threadIndex.Associate([]string{outboundMessageID}, target.ThreadID); indexErr != nil {
+			e.logger.Printf("[email] Warning: failed to index outbound Message-ID: %v", indexErr)
+		}
+	}
+
+	return nil
 }
 
 // BroadcastTargets returns one target per allowed sender address.
 func (e *EmailChannel) BroadcastTargets() []channels.Target {
+	e.allowMu.RLock()
+	defer e.allowMu.RUnlock()
 	var targets []channels.Target
-	for _, addr := range e.config.AllowFrom {
-		if addr == "*" {
-			continue
-		}
+	for addr := range e.allowSet {
 		targets = append(targets, channels.Target{
 			ChannelID: "email",
 			ChatID:    addr,
@@ -295,21 +327,26 @@ func (e *EmailChannel) checkNewEmails(ctx context.Context) {
 			continue
 		}
 
-		// Read full message for the body
+		// Read full message for the body and threading headers
 		fullMsg, err := client.ReadMessage(ctx, summary.ID)
 		if err != nil {
 			e.logger.Printf("[email] Error reading message %s: %v", summary.ID, err)
 			continue
 		}
 
+		// Determine the session routing via thread-based routing
+		threadSessionKey := e.resolveThreadSession(senderAddr, fullMsg)
+
 		// Build normalized inbound message
 		inbound := channels.InboundMessage{
 			ID:         summary.ID,
+			MessageID:  fullMsg.Headers["Message-ID"],
 			ChannelID:  "email",
 			SenderID:   senderAddr,
 			SenderName: extractName(summary.From),
-			ChatID:     senderAddr, // Session key uses sender address
+			ChatID:     senderAddr, // Delivery address (for sending replies)
 			ChatType:   channels.ChatTypeDirect,
+			ThreadID:   threadSessionKey, // Thread-specific session key (overrides Router)
 			Text:       fullMsg.Body,
 			Timestamp:  summary.Date,
 			Raw:        fullMsg,
@@ -338,8 +375,97 @@ func (e *EmailChannel) checkNewEmails(ctx context.Context) {
 	e.seenMu.Unlock()
 }
 
+// resolveThreadSession determines the full session key for an email based on
+// threading headers. If thread indexing is enabled:
+//   - Replies (In-Reply-To / References) are matched to existing sessions
+//   - New emails (no threading headers or no match) create new thread sessions
+//
+// Returns the full session key (e.g., "email:direct:alice@example.com-a1b2c3d4")
+// which is placed in InboundMessage.ThreadID to override the Router.
+// Without thread indexing, returns empty string (Router falls back to ChatID).
+func (e *EmailChannel) resolveThreadSession(senderAddr string, msg *emailpkg.Message) string {
+	if e.threadIndex == nil {
+		return "" // fallback: per-sender session via ChatID
+	}
+
+	messageID := msg.Headers["Message-ID"]
+	inReplyTo := msg.Headers["In-Reply-To"]
+	references := msg.Headers["References"]
+
+	// Build the chain of parent Message-IDs to look up (newest first)
+	var parentIDs []string
+	if inReplyTo != "" {
+		parentIDs = append(parentIDs, inReplyTo)
+	}
+	// Parse References header: space-separated list of Message-IDs
+	if references != "" {
+		refs := parseReferences(references)
+		// Walk in reverse (newest first) for faster matching
+		for i := len(refs) - 1; i >= 0; i-- {
+			// Skip duplicates with In-Reply-To
+			if refs[i] != inReplyTo {
+				parentIDs = append(parentIDs, refs[i])
+			}
+		}
+	}
+
+	// Try to find an existing session via thread chain
+	if len(parentIDs) > 0 {
+		if sessionKey, ok := e.threadIndex.LookupChain(parentIDs); ok {
+			// Index the current Message-ID to this session too
+			if messageID != "" {
+				if err := e.threadIndex.Associate([]string{messageID}, sessionKey); err != nil {
+					e.logger.Printf("[email] Warning: failed to index Message-ID %s: %v", messageID, err)
+				}
+			}
+			return sessionKey
+		}
+	}
+
+	// No match — this is a new thread. Generate a thread-specific session key.
+	threadID := generateThreadID(senderAddr, messageID)
+	sessionKey := fmt.Sprintf("email:%s:%s", channels.ChatTypeDirect, threadID)
+
+	// Index the current Message-ID so future replies can find this session.
+	if messageID != "" {
+		if err := e.threadIndex.Associate([]string{messageID}, sessionKey); err != nil {
+			e.logger.Printf("[email] Warning: failed to index Message-ID %s: %v", messageID, err)
+		}
+	}
+
+	return sessionKey
+}
+
+// generateThreadID creates a deterministic, human-readable thread identifier
+// from the sender address and Message-ID. Format: <sender>-<short-hash>.
+// The hash ensures uniqueness across threads from the same sender.
+func generateThreadID(senderAddr, messageID string) string {
+	if messageID == "" {
+		// Fallback for messages without a Message-ID (extremely rare)
+		messageID = fmt.Sprintf("noid-%d", time.Now().UnixNano())
+	}
+	h := sha256.Sum256([]byte(messageID))
+	shortHash := fmt.Sprintf("%x", h[:4]) // 8 hex chars
+	return fmt.Sprintf("%s-%s", senderAddr, shortHash)
+}
+
+// parseReferences splits a References header value into individual Message-IDs.
+// The References header contains space-separated Message-IDs per RFC 2822.
+func parseReferences(refs string) []string {
+	var result []string
+	for _, part := range strings.Fields(refs) {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}
+
 // isAllowed checks if a sender is in the allowlist.
 func (e *EmailChannel) isAllowed(senderAddr string) bool {
+	e.allowMu.RLock()
+	defer e.allowMu.RUnlock()
 	if e.allowAll {
 		return true
 	}
@@ -347,6 +473,37 @@ func (e *EmailChannel) isAllowed(senderAddr string) bool {
 		return false
 	}
 	return e.allowSet[strings.ToLower(senderAddr)]
+}
+
+// UpdateAllowlist replaces the sender allowlist at runtime without requiring
+// a channel restart. It also clears the seenIDs cache so that previously
+// blocked (but still unread) emails are re-evaluated on the next poll cycle.
+// Implements the channels.AllowlistUpdater interface.
+func (e *EmailChannel) UpdateAllowlist(allowFrom []string) {
+	newSet := make(map[string]bool, len(allowFrom))
+	newAll := false
+	for _, addr := range allowFrom {
+		if addr == "*" {
+			newAll = true
+		} else {
+			newSet[strings.ToLower(addr)] = true
+		}
+	}
+
+	e.allowMu.Lock()
+	e.allowSet = newSet
+	e.allowAll = newAll
+	e.allowMu.Unlock()
+
+	// Clear seenIDs so previously-blocked (but still unread) emails
+	// are re-evaluated with the new allowlist on the next poll cycle.
+	// This is safe because processed emails are already marked as read
+	// on the IMAP server and won't appear in the NOT \Seen search.
+	e.seenMu.Lock()
+	e.seenIDs = make(map[string]bool)
+	e.seenMu.Unlock()
+
+	e.logger.Printf("[email] Allowlist updated (%d entries), cleared seen cache", len(allowFrom))
 }
 
 // setError updates the channel status with an error message.

--- a/pkg/channels/email/email_test.go
+++ b/pkg/channels/email/email_test.go
@@ -2,8 +2,12 @@ package email
 
 import (
 	"log"
+	"path/filepath"
 	"testing"
 	"time"
+
+	emailpkg "github.com/schardosin/astonish/pkg/email"
+	"github.com/schardosin/astonish/pkg/session"
 )
 
 func TestExtractEmailAddr(t *testing.T) {
@@ -186,4 +190,345 @@ func TestNewDefaults(t *testing.T) {
 			t.Error("logger should not be nil when nil is passed")
 		}
 	})
+}
+
+func TestUpdateAllowlist(t *testing.T) {
+	t.Parallel()
+	logger := log.Default()
+
+	t.Run("replaces existing allowlist", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Address:   "bot@example.com",
+			AllowFrom: []string{"old@example.com"},
+		}
+		ch := New(cfg, logger)
+
+		if !ch.isAllowed("old@example.com") {
+			t.Fatal("old address should be allowed before update")
+		}
+
+		ch.UpdateAllowlist([]string{"new@example.com", "another@example.com"})
+
+		if ch.isAllowed("old@example.com") {
+			t.Error("old address should be blocked after update")
+		}
+		if !ch.isAllowed("new@example.com") {
+			t.Error("new@example.com should be allowed after update")
+		}
+		if !ch.isAllowed("another@example.com") {
+			t.Error("another@example.com should be allowed after update")
+		}
+	})
+
+	t.Run("handles wildcard", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Address:   "bot@example.com",
+			AllowFrom: []string{"only@example.com"},
+		}
+		ch := New(cfg, logger)
+
+		ch.UpdateAllowlist([]string{"*"})
+
+		if !ch.isAllowed("anyone@anywhere.com") {
+			t.Error("wildcard should allow any address")
+		}
+	})
+
+	t.Run("wildcard to specific", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Address:   "bot@example.com",
+			AllowFrom: []string{"*"},
+		}
+		ch := New(cfg, logger)
+
+		if !ch.isAllowed("random@test.com") {
+			t.Fatal("wildcard should allow any address before update")
+		}
+
+		ch.UpdateAllowlist([]string{"specific@example.com"})
+
+		if ch.isAllowed("random@test.com") {
+			t.Error("random address should be blocked after switching from wildcard to specific")
+		}
+		if !ch.isAllowed("specific@example.com") {
+			t.Error("specific address should be allowed after update")
+		}
+	})
+
+	t.Run("empty list blocks all", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Address:   "bot@example.com",
+			AllowFrom: []string{"allowed@example.com"},
+		}
+		ch := New(cfg, logger)
+
+		ch.UpdateAllowlist([]string{})
+
+		if ch.isAllowed("allowed@example.com") {
+			t.Error("empty allowlist should block all addresses")
+		}
+	})
+
+	t.Run("clears seenIDs", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Address:   "bot@example.com",
+			AllowFrom: []string{"allowed@example.com"},
+		}
+		ch := New(cfg, logger)
+
+		// Simulate some seen message IDs
+		ch.seenMu.Lock()
+		ch.seenIDs["msg-1"] = true
+		ch.seenIDs["msg-2"] = true
+		ch.seenMu.Unlock()
+
+		ch.UpdateAllowlist([]string{"allowed@example.com", "new@example.com"})
+
+		ch.seenMu.Lock()
+		seenCount := len(ch.seenIDs)
+		ch.seenMu.Unlock()
+
+		if seenCount != 0 {
+			t.Errorf("seenIDs should be empty after UpdateAllowlist, got %d entries", seenCount)
+		}
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{Address: "bot@example.com"}
+		ch := New(cfg, logger)
+
+		ch.UpdateAllowlist([]string{"Alice@Example.COM"})
+
+		if !ch.isAllowed("alice@example.com") {
+			t.Error("allowlist should be case-insensitive after update")
+		}
+	})
+}
+
+// --- Thread-based session routing tests ---
+
+func newTestEmailChannel(t *testing.T) (*EmailChannel, *session.ThreadIndex) {
+	t.Helper()
+	dir := t.TempDir()
+	idx := session.NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+	ch := New(&Config{Address: "bot@test.com"}, log.Default())
+	ch.SetThreadIndex(idx)
+	return ch, idx
+}
+
+func TestResolveThreadSession_NewEmail(t *testing.T) {
+	ch, idx := newTestEmailChannel(t)
+
+	// New email (no In-Reply-To, no References) should create a new thread session
+	msg := &emailpkg.Message{
+		Headers: map[string]string{
+			"Message-ID": "<new-thread@example.com>",
+		},
+	}
+
+	sessionKey := ch.resolveThreadSession("alice@example.com", msg)
+	if sessionKey == "" {
+		t.Fatal("expected non-empty session key for new thread")
+	}
+	if sessionKey == "alice@example.com" {
+		t.Error("session key should NOT be the sender address (should be thread-specific)")
+	}
+
+	// The Message-ID should now be indexed
+	got, ok := idx.Lookup("<new-thread@example.com>")
+	if !ok {
+		t.Fatal("expected Message-ID to be indexed after resolveThreadSession")
+	}
+	if got != sessionKey {
+		t.Errorf("indexed session key = %q, want %q", got, sessionKey)
+	}
+}
+
+func TestResolveThreadSession_Reply(t *testing.T) {
+	ch, idx := newTestEmailChannel(t)
+
+	// Set up: original email created a session
+	origSessionKey := "email:direct:alice@example.com-abcd1234"
+	_ = idx.Associate([]string{"<original@example.com>"}, origSessionKey)
+
+	// Reply to the original email
+	msg := &emailpkg.Message{
+		Headers: map[string]string{
+			"Message-ID":  "<reply-1@example.com>",
+			"In-Reply-To": "<original@example.com>",
+		},
+	}
+
+	sessionKey := ch.resolveThreadSession("alice@example.com", msg)
+	if sessionKey != origSessionKey {
+		t.Errorf("reply should route to original session: got %q, want %q", sessionKey, origSessionKey)
+	}
+
+	// The reply's Message-ID should also be indexed to the same session
+	got, ok := idx.Lookup("<reply-1@example.com>")
+	if !ok {
+		t.Fatal("reply Message-ID should be indexed")
+	}
+	if got != origSessionKey {
+		t.Errorf("reply indexed to %q, want %q", got, origSessionKey)
+	}
+}
+
+func TestResolveThreadSession_ReferencesChainFallback(t *testing.T) {
+	ch, idx := newTestEmailChannel(t)
+
+	// Set up: an old message in the thread is indexed
+	origSessionKey := "email:direct:bob@example.com-feed0001"
+	_ = idx.Associate([]string{"<msg-1@example.com>"}, origSessionKey)
+
+	// A reply arrives where In-Reply-To points to an unindexed message,
+	// but References includes the older indexed message
+	msg := &emailpkg.Message{
+		Headers: map[string]string{
+			"Message-ID":  "<msg-3@example.com>",
+			"In-Reply-To": "<msg-2@example.com>", // not indexed
+			"References":  "<msg-1@example.com> <msg-2@example.com>",
+		},
+	}
+
+	sessionKey := ch.resolveThreadSession("bob@example.com", msg)
+	if sessionKey != origSessionKey {
+		t.Errorf("should fall back to References chain: got %q, want %q", sessionKey, origSessionKey)
+	}
+}
+
+func TestResolveThreadSession_NoThreadIndex(t *testing.T) {
+	// Without thread index, should return empty (fall back to Router's ChatID)
+	ch := New(&Config{Address: "bot@test.com"}, log.Default())
+
+	msg := &emailpkg.Message{
+		Headers: map[string]string{
+			"Message-ID": "<test@example.com>",
+		},
+	}
+
+	sessionKey := ch.resolveThreadSession("alice@example.com", msg)
+	if sessionKey != "" {
+		t.Errorf("without thread index, should return empty string, got %q", sessionKey)
+	}
+}
+
+func TestResolveThreadSession_DifferentSendersNewThreads(t *testing.T) {
+	ch, _ := newTestEmailChannel(t)
+
+	// Two new emails from different senders should create different sessions
+	msg1 := &emailpkg.Message{
+		Headers: map[string]string{"Message-ID": "<alice-1@example.com>"},
+	}
+	msg2 := &emailpkg.Message{
+		Headers: map[string]string{"Message-ID": "<bob-1@example.com>"},
+	}
+
+	session1 := ch.resolveThreadSession("alice@example.com", msg1)
+	session2 := ch.resolveThreadSession("bob@example.com", msg2)
+
+	if session1 == session2 {
+		t.Error("different senders should get different sessions")
+	}
+}
+
+func TestResolveThreadSession_SameSenderDifferentThreads(t *testing.T) {
+	ch, _ := newTestEmailChannel(t)
+
+	// Two new emails from the same sender should create different sessions
+	msg1 := &emailpkg.Message{
+		Headers: map[string]string{"Message-ID": "<alice-thread1@example.com>"},
+	}
+	msg2 := &emailpkg.Message{
+		Headers: map[string]string{"Message-ID": "<alice-thread2@example.com>"},
+	}
+
+	session1 := ch.resolveThreadSession("alice@example.com", msg1)
+	session2 := ch.resolveThreadSession("alice@example.com", msg2)
+
+	if session1 == session2 {
+		t.Error("different threads from same sender should get different sessions")
+	}
+}
+
+func TestGenerateThreadID(t *testing.T) {
+	// Same inputs should produce the same thread ID (deterministic)
+	id1 := generateThreadID("alice@example.com", "<msg@ex.com>")
+	id2 := generateThreadID("alice@example.com", "<msg@ex.com>")
+	if id1 != id2 {
+		t.Errorf("generateThreadID should be deterministic: %q != %q", id1, id2)
+	}
+
+	// Different Message-IDs should produce different thread IDs
+	id3 := generateThreadID("alice@example.com", "<other@ex.com>")
+	if id1 == id3 {
+		t.Error("different Message-IDs should produce different thread IDs")
+	}
+
+	// Should contain the sender address for readability
+	if !contains(id1, "alice@example.com") {
+		t.Errorf("thread ID should contain sender address: %q", id1)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstring(s, substr))
+}
+
+func findSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func TestParseReferences(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "single reference",
+			input: "<msg1@example.com>",
+			want:  []string{"<msg1@example.com>"},
+		},
+		{
+			name:  "multiple references",
+			input: "<msg1@example.com> <msg2@example.com> <msg3@example.com>",
+			want:  []string{"<msg1@example.com>", "<msg2@example.com>", "<msg3@example.com>"},
+		},
+		{
+			name:  "extra whitespace",
+			input: "  <msg1@example.com>   <msg2@example.com>  ",
+			want:  []string{"<msg1@example.com>", "<msg2@example.com>"},
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseReferences(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseReferences(%q) = %v (len %d), want %v (len %d)", tt.input, got, len(got), tt.want, len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseReferences(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
 }

--- a/pkg/channels/fleet_commands.go
+++ b/pkg/channels/fleet_commands.go
@@ -41,7 +41,11 @@ func fleetCommand(mgr *ChannelManager) *Command {
 
 			// Check if a fleet session is already active for this chat
 			if sessionID := mgr.GetActiveFleet(cc.SessionKey); sessionID != "" {
-				return fmt.Sprintf("A fleet session is already active (%s). Use /fleet_stop to end it first.", sessionID[:8]), nil
+				shortID := sessionID
+				if len(shortID) > 16 {
+					shortID = shortID[:16]
+				}
+				return fmt.Sprintf("A fleet session is already active (%s). Use /fleet_stop to end it first.", shortID), nil
 			}
 
 			args := strings.TrimSpace(strings.TrimPrefix(cc.RawText, "/fleet"))

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -266,6 +266,25 @@ func (m *ChannelManager) Status() map[string]ChannelStatus {
 	return statuses
 }
 
+// UpdateAllowlists updates the sender allowlists on running channels that
+// implement AllowlistUpdater. The allowlists map is keyed by channel ID
+// (e.g. "email", "telegram"). Returns true if any channel was updated.
+func (m *ChannelManager) UpdateAllowlists(allowlists map[string][]string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	updated := false
+	for id, ch := range m.channels {
+		if updater, ok := ch.(AllowlistUpdater); ok {
+			if newList, has := allowlists[id]; has {
+				updater.UpdateAllowlist(newList)
+				updated = true
+			}
+		}
+	}
+	return updated
+}
+
 // --- Fleet session tracking ---
 
 // SetActiveFleet associates a chat session key with an active fleet session ID.

--- a/pkg/channels/router.go
+++ b/pkg/channels/router.go
@@ -20,8 +20,12 @@ func NewRouter() *Router {
 }
 
 // Route determines the session key for an inbound message.
-// In Phase 1, all messages are routed to the default ChatAgent.
+// If ThreadID is set, it is used directly as the session key (used by email
+// for per-thread sessions). Otherwise, the key is derived from channel metadata.
 func (r *Router) Route(msg InboundMessage) RouteResult {
+	if msg.ThreadID != "" {
+		return RouteResult{SessionKey: msg.ThreadID}
+	}
 	return RouteResult{
 		SessionKey: fmt.Sprintf("%s:%s:%s", msg.ChannelID, msg.ChatType, msg.ChatID),
 	}

--- a/pkg/channels/router_test.go
+++ b/pkg/channels/router_test.go
@@ -63,4 +63,32 @@ func TestRouter_Route(t *testing.T) {
 			t.Errorf("same inputs should produce same key, got %q and %q", r1.SessionKey, r2.SessionKey)
 		}
 	})
+
+	t.Run("ThreadID overrides ChatID for session key", func(t *testing.T) {
+		msg := InboundMessage{
+			ChannelID: "email",
+			ChatType:  ChatTypeDirect,
+			ChatID:    "alice@example.com",
+			ThreadID:  "email:direct:alice@example.com-a1b2c3d4",
+		}
+		result := r.Route(msg)
+		want := "email:direct:alice@example.com-a1b2c3d4"
+		if result.SessionKey != want {
+			t.Errorf("Route() with ThreadID = %q, want %q", result.SessionKey, want)
+		}
+	})
+
+	t.Run("empty ThreadID falls back to ChatID", func(t *testing.T) {
+		msg := InboundMessage{
+			ChannelID: "telegram",
+			ChatType:  ChatTypeDirect,
+			ChatID:    "12345",
+			ThreadID:  "",
+		}
+		result := r.Route(msg)
+		want := "telegram:direct:12345"
+		if result.SessionKey != want {
+			t.Errorf("Route() with empty ThreadID = %q, want %q", result.SessionKey, want)
+		}
+	})
 }

--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -46,6 +46,7 @@ type TelegramChannel struct {
 	msgCount atomic.Int64
 
 	// allowSet is built from config.AllowFrom for fast lookup.
+	allowMu  sync.RWMutex
 	allowSet map[string]bool
 }
 
@@ -315,6 +316,8 @@ func (t *TelegramChannel) Status() channels.ChannelStatus {
 // In direct messages, Telegram chat ID == user ID, so each AllowFrom
 // entry becomes a delivery target.
 func (t *TelegramChannel) BroadcastTargets() []channels.Target {
+	t.allowMu.RLock()
+	defer t.allowMu.RUnlock()
 	targets := make([]channels.Target, 0, len(t.allowSet))
 	for id := range t.allowSet {
 		targets = append(targets, channels.Target{
@@ -336,7 +339,10 @@ func (t *TelegramChannel) processUpdate(ctx context.Context, update tgbotapi.Upd
 
 	// Allowlist check — only explicitly allowed senders can interact.
 	// An empty allowlist blocks everyone (safe default for a bot with tool access).
-	if !t.allowSet[senderID] {
+	t.allowMu.RLock()
+	allowed := t.allowSet[senderID]
+	t.allowMu.RUnlock()
+	if !allowed {
 		t.logger.Printf("[telegram] Blocked message from unauthorized sender %s (%s)",
 			senderID, msg.From.UserName)
 		return
@@ -422,6 +428,21 @@ func (t *TelegramChannel) setError(errMsg string) {
 	defer t.mu.Unlock()
 	t.status.Error = errMsg
 	t.status.Connected = false
+}
+
+// UpdateAllowlist replaces the sender allowlist at runtime without requiring
+// a channel restart. Implements the channels.AllowlistUpdater interface.
+func (t *TelegramChannel) UpdateAllowlist(allowFrom []string) {
+	newSet := make(map[string]bool, len(allowFrom))
+	for _, id := range allowFrom {
+		newSet[id] = true
+	}
+
+	t.allowMu.Lock()
+	t.allowSet = newSet
+	t.allowMu.Unlock()
+
+	t.logger.Printf("[telegram] Allowlist updated (%d entries)", len(allowFrom))
 }
 
 // registerBotCommands calls Telegram's setMyCommands API to populate the

--- a/pkg/daemon/config_watcher.go
+++ b/pkg/daemon/config_watcher.go
@@ -1,0 +1,253 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/schardosin/astonish/pkg/channels"
+	"github.com/schardosin/astonish/pkg/config"
+)
+
+// ConfigWatcherOpts holds the options for the config file watcher.
+type ConfigWatcherOpts struct {
+	// DebounceMs is the debounce window in milliseconds. Default: 1500.
+	DebounceMs int
+	// Logger for watcher messages.
+	Logger *Logger
+	// GetManager returns the current ChannelManager (may change on full reload).
+	GetManager func() *channels.ChannelManager
+	// ReloadChannels triggers a full channel reload (stop all, re-read config, start all).
+	ReloadChannels func() error
+	// LastConfig is the config snapshot at daemon startup, used as the baseline
+	// for change detection.
+	LastConfig *config.AppConfig
+}
+
+// channelSnapshot captures the channel-relevant fields from AppConfig for
+// comparison. Structural fields require a full channel reload when changed,
+// while AllowFrom changes can be applied in-place.
+type channelSnapshot struct {
+	// Top-level
+	ChannelsEnabled bool
+
+	// Email structural fields
+	EmailEnabled      bool
+	EmailProvider     string
+	EmailIMAPServer   string
+	EmailSMTPServer   string
+	EmailAddress      string
+	EmailUsername     string
+	EmailPollInterval int
+	EmailFolder       string
+	EmailMarkRead     bool
+	EmailMaxBodyChars int
+
+	// Email allowlist (hot-reloadable)
+	EmailAllowFrom []string
+
+	// Telegram structural fields
+	TelegramEnabled bool
+
+	// Telegram allowlist (hot-reloadable)
+	TelegramAllowFrom []string
+}
+
+// takeSnapshot extracts channel-relevant fields from an AppConfig.
+func takeSnapshot(cfg *config.AppConfig) channelSnapshot {
+	s := channelSnapshot{
+		ChannelsEnabled:   cfg.Channels.IsChannelsEnabled(),
+		EmailEnabled:      cfg.Channels.Email.IsEmailEnabled(),
+		EmailProvider:     cfg.Channels.Email.Provider,
+		EmailIMAPServer:   cfg.Channels.Email.IMAPServer,
+		EmailSMTPServer:   cfg.Channels.Email.SMTPServer,
+		EmailAddress:      cfg.Channels.Email.Address,
+		EmailUsername:     cfg.Channels.Email.Username,
+		EmailPollInterval: cfg.Channels.Email.PollInterval,
+		EmailFolder:       cfg.Channels.Email.Folder,
+		EmailMarkRead:     cfg.Channels.Email.IsMarkRead(),
+		EmailMaxBodyChars: cfg.Channels.Email.MaxBodyChars,
+		EmailAllowFrom:    cfg.Channels.Email.AllowFrom,
+		TelegramEnabled:   cfg.Channels.Telegram.IsTelegramEnabled(),
+		TelegramAllowFrom: cfg.Channels.Telegram.AllowFrom,
+	}
+	return s
+}
+
+// needsFullReload returns true if any structural (non-allowlist) channel
+// config field has changed, requiring a full channel tear-down and rebuild.
+func needsFullReload(old, new channelSnapshot) bool {
+	if old.ChannelsEnabled != new.ChannelsEnabled {
+		return true
+	}
+
+	// Email structural fields
+	if old.EmailEnabled != new.EmailEnabled ||
+		old.EmailProvider != new.EmailProvider ||
+		old.EmailIMAPServer != new.EmailIMAPServer ||
+		old.EmailSMTPServer != new.EmailSMTPServer ||
+		old.EmailAddress != new.EmailAddress ||
+		old.EmailUsername != new.EmailUsername ||
+		old.EmailPollInterval != new.EmailPollInterval ||
+		old.EmailFolder != new.EmailFolder ||
+		old.EmailMarkRead != new.EmailMarkRead ||
+		old.EmailMaxBodyChars != new.EmailMaxBodyChars {
+		return true
+	}
+
+	// Telegram structural fields
+	if old.TelegramEnabled != new.TelegramEnabled {
+		return true
+	}
+
+	return false
+}
+
+// allowlistChanged returns a map of channel ID to new allowlist for channels
+// whose AllowFrom list has changed. Returns nil if no allowlists changed.
+func allowlistChanged(old, new channelSnapshot) map[string][]string {
+	changes := make(map[string][]string)
+
+	if !slicesEqual(old.EmailAllowFrom, new.EmailAllowFrom) {
+		changes["email"] = new.EmailAllowFrom
+	}
+	if !slicesEqual(old.TelegramAllowFrom, new.TelegramAllowFrom) {
+		changes["telegram"] = new.TelegramAllowFrom
+	}
+
+	if len(changes) == 0 {
+		return nil
+	}
+	return changes
+}
+
+// slicesEqual compares two string slices for equality (order-independent).
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	aSorted := make([]string, len(a))
+	bSorted := make([]string, len(b))
+	copy(aSorted, a)
+	copy(bSorted, b)
+	sort.Strings(aSorted)
+	sort.Strings(bSorted)
+	for i := range aSorted {
+		if aSorted[i] != bSorted[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// WatchConfig watches the config file for changes and triggers appropriate
+// reload actions: in-place allowlist updates for allow_from changes, full
+// channel reload for structural changes.
+//
+// This function blocks until ctx is cancelled. It follows the same
+// fsnotify + debounce pattern used by the memory file watcher.
+func WatchConfig(ctx context.Context, configPath string, opts ConfigWatcherOpts) error {
+	if opts.DebounceMs <= 0 {
+		opts.DebounceMs = 1500
+	}
+	logger := opts.Logger
+	if logger == nil {
+		return fmt.Errorf("config watcher requires a logger")
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	if err := watcher.Add(configPath); err != nil {
+		return err
+	}
+
+	lastSnapshot := takeSnapshot(opts.LastConfig)
+
+	var debounceTimer *time.Timer
+	var debounceMu sync.Mutex
+
+	handleChange := func() {
+		freshCfg, err := config.LoadAppConfig()
+		if err != nil {
+			logger.Printf("[config-watcher] Error reading config: %v", err)
+			return
+		}
+
+		newSnapshot := takeSnapshot(freshCfg)
+
+		if needsFullReload(lastSnapshot, newSnapshot) {
+			logger.Printf("[config-watcher] Structural channel config changed, performing full reload")
+			if err := opts.ReloadChannels(); err != nil {
+				logger.Printf("[config-watcher] Full reload error: %v", err)
+			}
+			lastSnapshot = newSnapshot
+			return
+		}
+
+		if changes := allowlistChanged(lastSnapshot, newSnapshot); changes != nil {
+			mgr := opts.GetManager()
+			if mgr != nil {
+				mgr.UpdateAllowlists(changes)
+				logger.Printf("[config-watcher] Allowlist(s) updated in-place")
+			}
+			lastSnapshot = newSnapshot
+			return
+		}
+
+		// Non-channel config changed — no action needed for channels.
+		lastSnapshot = newSnapshot
+	}
+
+	logger.Printf("[config-watcher] Watching %s for changes", configPath)
+
+	for {
+		select {
+		case <-ctx.Done():
+			debounceMu.Lock()
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceMu.Unlock()
+			return nil
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+				debounceMu.Lock()
+				if debounceTimer != nil {
+					debounceTimer.Stop()
+				}
+				debounceTimer = time.AfterFunc(time.Duration(opts.DebounceMs)*time.Millisecond, handleChange)
+				debounceMu.Unlock()
+			}
+
+			// Some editors (vim, etc.) perform atomic saves by renaming a
+			// temp file over the original. This removes the original inode
+			// from the watcher. Re-add the path to keep watching.
+			if event.Has(fsnotify.Rename) || event.Has(fsnotify.Remove) {
+				// Small delay to let the editor finish writing the new file.
+				time.Sleep(100 * time.Millisecond)
+				_ = watcher.Add(configPath)
+			}
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			logger.Printf("[config-watcher] Watcher error: %v", err)
+		}
+	}
+}

--- a/pkg/daemon/config_watcher_test.go
+++ b/pkg/daemon/config_watcher_test.go
@@ -1,0 +1,273 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/schardosin/astonish/pkg/config"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestNeedsFullReload(t *testing.T) {
+	t.Parallel()
+
+	base := func() *config.AppConfig {
+		return &config.AppConfig{
+			Channels: config.ChannelsConfig{
+				Enabled: boolPtr(true),
+				Telegram: config.TelegramConfig{
+					Enabled:   boolPtr(true),
+					AllowFrom: []string{"123"},
+				},
+				Email: config.EmailConfig{
+					Enabled:      boolPtr(true),
+					Provider:     "imap",
+					IMAPServer:   "imap.gmail.com:993",
+					SMTPServer:   "smtp.gmail.com:587",
+					Address:      "bot@example.com",
+					Username:     "bot@example.com",
+					PollInterval: 30,
+					Folder:       "INBOX",
+					MarkRead:     boolPtr(true),
+					MaxBodyChars: 50000,
+					AllowFrom:    []string{"user@example.com"},
+				},
+			},
+		}
+	}
+
+	t.Run("no changes", func(t *testing.T) {
+		t.Parallel()
+		old := takeSnapshot(base())
+		new := takeSnapshot(base())
+		if needsFullReload(old, new) {
+			t.Error("identical configs should not need full reload")
+		}
+	})
+
+	t.Run("allowlist only change does not need full reload", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Email.AllowFrom = []string{"user@example.com", "new@example.com"}
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		if needsFullReload(old, new) {
+			t.Error("allowlist-only change should not need full reload")
+		}
+	})
+
+	t.Run("telegram allowlist only change does not need full reload", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Telegram.AllowFrom = []string{"123", "456"}
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		if needsFullReload(old, new) {
+			t.Error("telegram allowlist-only change should not need full reload")
+		}
+	})
+
+	t.Run("IMAP server change needs full reload", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Email.IMAPServer = "imap.other.com:993"
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		if !needsFullReload(old, new) {
+			t.Error("IMAP server change should need full reload")
+		}
+	})
+
+	t.Run("SMTP server change needs full reload", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Email.SMTPServer = "smtp.other.com:587"
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		if !needsFullReload(old, new) {
+			t.Error("SMTP server change should need full reload")
+		}
+	})
+
+	t.Run("email enabled change needs full reload", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Email.Enabled = boolPtr(false)
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		if !needsFullReload(old, new) {
+			t.Error("email enabled change should need full reload")
+		}
+	})
+
+	t.Run("channels enabled change needs full reload", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Enabled = boolPtr(false)
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		if !needsFullReload(old, new) {
+			t.Error("channels enabled change should need full reload")
+		}
+	})
+
+	t.Run("poll interval change needs full reload", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Email.PollInterval = 60
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		if !needsFullReload(old, new) {
+			t.Error("poll interval change should need full reload")
+		}
+	})
+
+	t.Run("telegram enabled change needs full reload", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Telegram.Enabled = boolPtr(false)
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		if !needsFullReload(old, new) {
+			t.Error("telegram enabled change should need full reload")
+		}
+	})
+}
+
+func TestAllowlistChanged(t *testing.T) {
+	t.Parallel()
+
+	base := func() *config.AppConfig {
+		return &config.AppConfig{
+			Channels: config.ChannelsConfig{
+				Enabled: boolPtr(true),
+				Telegram: config.TelegramConfig{
+					Enabled:   boolPtr(true),
+					AllowFrom: []string{"123"},
+				},
+				Email: config.EmailConfig{
+					Enabled:   boolPtr(true),
+					AllowFrom: []string{"user@example.com"},
+				},
+			},
+		}
+	}
+
+	t.Run("no changes returns nil", func(t *testing.T) {
+		t.Parallel()
+		old := takeSnapshot(base())
+		new := takeSnapshot(base())
+		if changes := allowlistChanged(old, new); changes != nil {
+			t.Errorf("identical allowlists should return nil, got %v", changes)
+		}
+	})
+
+	t.Run("email allowlist added", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Email.AllowFrom = []string{"user@example.com", "new@sap.com"}
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		changes := allowlistChanged(old, new)
+		if changes == nil {
+			t.Fatal("should detect email allowlist change")
+		}
+		if _, has := changes["email"]; !has {
+			t.Error("changes should contain 'email' key")
+		}
+		if _, has := changes["telegram"]; has {
+			t.Error("changes should not contain 'telegram' key (unchanged)")
+		}
+	})
+
+	t.Run("telegram allowlist changed", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Telegram.AllowFrom = []string{"123", "456"}
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		changes := allowlistChanged(old, new)
+		if changes == nil {
+			t.Fatal("should detect telegram allowlist change")
+		}
+		if _, has := changes["telegram"]; !has {
+			t.Error("changes should contain 'telegram' key")
+		}
+		if _, has := changes["email"]; has {
+			t.Error("changes should not contain 'email' key (unchanged)")
+		}
+	})
+
+	t.Run("both allowlists changed", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg2 := base()
+		cfg2.Channels.Email.AllowFrom = []string{"new@example.com"}
+		cfg2.Channels.Telegram.AllowFrom = []string{"789"}
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		changes := allowlistChanged(old, new)
+		if changes == nil {
+			t.Fatal("should detect both allowlist changes")
+		}
+		if _, has := changes["email"]; !has {
+			t.Error("changes should contain 'email' key")
+		}
+		if _, has := changes["telegram"]; !has {
+			t.Error("changes should contain 'telegram' key")
+		}
+	})
+
+	t.Run("order independent comparison", func(t *testing.T) {
+		t.Parallel()
+		cfg1 := base()
+		cfg1.Channels.Email.AllowFrom = []string{"a@example.com", "b@example.com"}
+		cfg2 := base()
+		cfg2.Channels.Email.AllowFrom = []string{"b@example.com", "a@example.com"}
+		old := takeSnapshot(cfg1)
+		new := takeSnapshot(cfg2)
+		if changes := allowlistChanged(old, new); changes != nil {
+			t.Error("same entries in different order should not count as changed")
+		}
+	})
+}
+
+func TestSlicesEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{"both nil", nil, nil, true},
+		{"both empty", []string{}, []string{}, true},
+		{"nil vs empty", nil, []string{}, true},
+		{"same elements same order", []string{"a", "b"}, []string{"a", "b"}, true},
+		{"same elements different order", []string{"b", "a"}, []string{"a", "b"}, true},
+		{"different lengths", []string{"a"}, []string{"a", "b"}, false},
+		{"different elements", []string{"a", "b"}, []string{"a", "c"}, false},
+		{"single element match", []string{"x"}, []string{"x"}, true},
+		{"single element mismatch", []string{"x"}, []string{"y"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := slicesEqual(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("slicesEqual(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -312,6 +312,12 @@ func Run(cfg RunConfig) error {
 					MaxBodyChars: freshCfg.Channels.Email.MaxBodyChars,
 					Commands:     mgr.Commands(),
 				}, log.Default())
+				// Inject thread index for per-thread email sessions.
+				// Each email thread gets its own session; replies chain back
+				// to the same session via In-Reply-To / References headers.
+				if sharedFileStore != nil {
+					em.SetThreadIndex(sharedFileStore.ThreadIndex())
+				}
 				mgr.Register(em)
 				logger.Printf("Email channel registered (%s)", freshCfg.Channels.Email.Address)
 			}
@@ -443,6 +449,24 @@ func Run(cfg RunConfig) error {
 		return nil
 	}
 	api.SetChannelReloadFunc(reloadChannels)
+
+	// --- Start config file watcher for hot-reload ---
+	configPath, configPathErr := config.GetConfigPath()
+	if configPathErr != nil {
+		logger.Printf("Warning: Failed to resolve config path for watcher: %v", configPathErr)
+	} else {
+		go func() {
+			if err := WatchConfig(ctx, configPath, ConfigWatcherOpts{
+				DebounceMs:     1500,
+				Logger:         logger,
+				GetManager:     func() *channels.ChannelManager { return channelMgr },
+				ReloadChannels: reloadChannels,
+				LastConfig:     appCfg,
+			}); err != nil {
+				logger.Printf("Warning: Config watcher stopped: %v", err)
+			}
+		}()
+	}
 
 	// --- Initialize scheduler if enabled ---
 	var sched *scheduler.Scheduler

--- a/pkg/email/client.go
+++ b/pkg/email/client.go
@@ -17,6 +17,8 @@ type MessageSummary struct {
 	Date           time.Time `json:"date"`
 	Unread         bool      `json:"unread"`
 	HasAttachments bool      `json:"has_attachments"`
+	MessageID      string    `json:"message_id,omitempty"`  // RFC 2822 Message-ID header
+	InReplyTo      string    `json:"in_reply_to,omitempty"` // RFC 2822 In-Reply-To header
 }
 
 // Message is a fully-parsed email.

--- a/pkg/email/imap.go
+++ b/pkg/email/imap.go
@@ -227,6 +227,10 @@ func (c *IMAPSMTPClient) ListMessages(ctx context.Context, opts ListOpts) ([]Mes
 			}
 			summary.Subject = env.Subject
 			summary.Date = env.Date
+			summary.MessageID = env.MessageID
+			if len(env.InReplyTo) > 0 {
+				summary.InReplyTo = env.InReplyTo[0]
+			}
 		}
 
 		// Check read/unread status
@@ -338,6 +342,12 @@ func (c *IMAPSMTPClient) ReadMessage(ctx context.Context, id string) (*Message, 
 	if bodyBytes != nil && len(bodyBytes) > 0 {
 		mailMsg, parseErr := mail.ReadMessage(bytes.NewReader(bodyBytes))
 		if parseErr == nil {
+			// Extract References header from raw MIME headers (not in IMAP ENVELOPE).
+			// This is the full threading chain used for robust thread matching.
+			if refs := mailMsg.Header.Get("References"); refs != "" {
+				result.Headers["References"] = refs
+			}
+
 			maxChars := c.cfg.MaxBodyChars
 			if maxChars <= 0 {
 				maxChars = 50000

--- a/pkg/email/parser.go
+++ b/pkg/email/parser.go
@@ -2,12 +2,14 @@ package email
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"log/slog"
 	"mime"
 	"mime/multipart"
+	"mime/quotedprintable"
 	"net/mail"
 	"regexp"
 	"strings"
@@ -40,6 +42,21 @@ type ParsedBody struct {
 	Attachments []AttachmentInfo
 }
 
+// decodeCTE wraps a reader with the appropriate Content-Transfer-Encoding
+// decoder. Email bodies and MIME parts are transmitted with encodings like
+// base64 or quoted-printable; the raw bytes must be decoded before use.
+func decodeCTE(r io.Reader, encoding string) io.Reader {
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "base64":
+		return base64.NewDecoder(base64.StdEncoding, r)
+	case "quoted-printable":
+		return quotedprintable.NewReader(r)
+	default:
+		// "7bit", "8bit", "binary", or empty — no decoding needed
+		return r
+	}
+}
+
 // ParseMIMEBody parses the body of an email message, extracting text, HTML,
 // and attachment metadata. The msg parameter should have its body positioned
 // at the start. maxBodyChars limits the size of text/html returned.
@@ -56,7 +73,8 @@ func ParseMIMEBody(msg *mail.Message, maxBodyChars int) (*ParsedBody, error) {
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		// Fall back to reading the whole body as text
-		body, readErr := io.ReadAll(io.LimitReader(msg.Body, int64(maxBodyChars)))
+		reader := decodeCTE(msg.Body, msg.Header.Get("Content-Transfer-Encoding"))
+		body, readErr := io.ReadAll(io.LimitReader(reader, int64(maxBodyChars)))
 		if readErr != nil {
 			return nil, readErr
 		}
@@ -75,12 +93,14 @@ func ParseMIMEBody(msg *mail.Message, maxBodyChars int) (*ParsedBody, error) {
 			return result, nil // Return partial results on error
 		}
 	} else if strings.HasPrefix(mediaType, "text/html") {
-		body, _ := io.ReadAll(io.LimitReader(msg.Body, int64(maxBodyChars)))
+		reader := decodeCTE(msg.Body, msg.Header.Get("Content-Transfer-Encoding"))
+		body, _ := io.ReadAll(io.LimitReader(reader, int64(maxBodyChars)))
 		result.HTML = string(body)
 		result.Text = htmlToText(result.HTML)
 	} else {
 		// text/plain or unknown — treat as text
-		body, _ := io.ReadAll(io.LimitReader(msg.Body, int64(maxBodyChars)))
+		reader := decodeCTE(msg.Body, msg.Header.Get("Content-Transfer-Encoding"))
+		body, _ := io.ReadAll(io.LimitReader(reader, int64(maxBodyChars)))
 		result.Text = string(body)
 	}
 
@@ -129,7 +149,8 @@ func parseMultipart(body io.Reader, boundary string, result *ParsedBody, maxChar
 
 		case strings.HasPrefix(partMediaType, "text/html"):
 			if result.HTML == "" {
-				data, _ := io.ReadAll(io.LimitReader(part, int64(maxChars)))
+				reader := decodeCTE(part, part.Header.Get("Content-Transfer-Encoding"))
+				data, _ := io.ReadAll(io.LimitReader(reader, int64(maxChars)))
 				result.HTML = string(data)
 				if result.Text == "" {
 					result.Text = htmlToText(result.HTML)
@@ -138,7 +159,8 @@ func parseMultipart(body io.Reader, boundary string, result *ParsedBody, maxChar
 
 		case strings.HasPrefix(partMediaType, "text/plain"):
 			if result.Text == "" {
-				data, _ := io.ReadAll(io.LimitReader(part, int64(maxChars)))
+				reader := decodeCTE(part, part.Header.Get("Content-Transfer-Encoding"))
+				data, _ := io.ReadAll(io.LimitReader(reader, int64(maxChars)))
 				result.Text = string(data)
 			}
 

--- a/pkg/email/parser_test.go
+++ b/pkg/email/parser_test.go
@@ -1,6 +1,8 @@
 package email
 
 import (
+	"encoding/base64"
+	"fmt"
 	"net/mail"
 	"strings"
 	"testing"
@@ -267,4 +269,233 @@ func TestIsTokenLike(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- Content-Transfer-Encoding decoding tests ---
+
+func TestParseMIMEBody_Base64PlainText(t *testing.T) {
+	// Simulate a non-multipart email with base64-encoded text/plain body
+	plaintext := "Hello, this is a base64-encoded email reply."
+	encoded := base64.StdEncoding.EncodeToString([]byte(plaintext))
+
+	raw := fmt.Sprintf("Content-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\n%s", encoded)
+	msg, err := mail.ReadMessage(strings.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := ParseMIMEBody(msg, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed.Text != plaintext {
+		t.Errorf("expected decoded text %q, got %q", plaintext, parsed.Text)
+	}
+}
+
+func TestParseMIMEBody_Base64HTML(t *testing.T) {
+	htmlContent := "<html><body><p>Hello <b>base64</b> world</p></body></html>"
+	encoded := base64.StdEncoding.EncodeToString([]byte(htmlContent))
+
+	raw := fmt.Sprintf("Content-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\n%s", encoded)
+	msg, err := mail.ReadMessage(strings.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := ParseMIMEBody(msg, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed.HTML != htmlContent {
+		t.Errorf("expected decoded HTML %q, got %q", htmlContent, parsed.HTML)
+	}
+	if !strings.Contains(parsed.Text, "base64") {
+		t.Errorf("expected text fallback to contain 'base64', got %q", parsed.Text)
+	}
+}
+
+func TestParseMIMEBody_QuotedPrintablePlainText(t *testing.T) {
+	// Quoted-printable encodes "=" as "=3D" and wraps long lines with "=\r\n"
+	raw := "Content-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\nHello =3D world, this is quoted-printable."
+	msg, err := mail.ReadMessage(strings.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := ParseMIMEBody(msg, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "Hello = world, this is quoted-printable."
+	if parsed.Text != want {
+		t.Errorf("expected decoded text %q, got %q", want, parsed.Text)
+	}
+}
+
+func TestParseMIMEBody_MultipartBase64(t *testing.T) {
+	// Simulate a multipart/alternative email where the text/plain part is base64
+	plaintext := "This is the reply text from Outlook."
+	encodedPlain := base64.StdEncoding.EncodeToString([]byte(plaintext))
+
+	htmlContent := "<html><body><p>This is the reply text from Outlook.</p></body></html>"
+	encodedHTML := base64.StdEncoding.EncodeToString([]byte(htmlContent))
+
+	raw := fmt.Sprintf("Content-Type: multipart/alternative; boundary=\"BOUNDARY123\"\r\n\r\n"+
+		"--BOUNDARY123\r\n"+
+		"Content-Type: text/plain; charset=utf-8\r\n"+
+		"Content-Transfer-Encoding: base64\r\n"+
+		"\r\n"+
+		"%s\r\n"+
+		"--BOUNDARY123\r\n"+
+		"Content-Type: text/html; charset=utf-8\r\n"+
+		"Content-Transfer-Encoding: base64\r\n"+
+		"\r\n"+
+		"%s\r\n"+
+		"--BOUNDARY123--\r\n",
+		encodedPlain, encodedHTML)
+
+	msg, err := mail.ReadMessage(strings.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := ParseMIMEBody(msg, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed.Text != plaintext {
+		t.Errorf("expected decoded text %q, got %q", plaintext, parsed.Text)
+	}
+	if parsed.HTML != htmlContent {
+		t.Errorf("expected decoded HTML %q, got %q", htmlContent, parsed.HTML)
+	}
+}
+
+func TestParseMIMEBody_MultipartQuotedPrintable(t *testing.T) {
+	raw := "Content-Type: multipart/alternative; boundary=\"QP_BOUNDARY\"\r\n\r\n" +
+		"--QP_BOUNDARY\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"Content-Transfer-Encoding: quoted-printable\r\n" +
+		"\r\n" +
+		"Price is =E2=82=AC100 (=3D EUR 100)\r\n" +
+		"--QP_BOUNDARY--\r\n"
+
+	msg, err := mail.ReadMessage(strings.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := ParseMIMEBody(msg, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// =E2=82=AC is the UTF-8 encoding of the Euro sign (€)
+	// =3D is "="
+	if !strings.Contains(parsed.Text, "€100") {
+		t.Errorf("expected Euro sign in decoded text, got %q", parsed.Text)
+	}
+	if !strings.Contains(parsed.Text, "= EUR 100") {
+		t.Errorf("expected decoded '= EUR 100' in text, got %q", parsed.Text)
+	}
+}
+
+func TestParseMIMEBody_7bitNoop(t *testing.T) {
+	// 7bit encoding should pass through unchanged
+	raw := "Content-Type: text/plain; charset=us-ascii\r\nContent-Transfer-Encoding: 7bit\r\n\r\nPlain ASCII text."
+	msg, err := mail.ReadMessage(strings.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := ParseMIMEBody(msg, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed.Text != "Plain ASCII text." {
+		t.Errorf("7bit text should pass through unchanged, got %q", parsed.Text)
+	}
+}
+
+func TestDecodeCTE(t *testing.T) {
+	tests := []struct {
+		name     string
+		encoding string
+		input    string
+		want     string
+	}{
+		{
+			name:     "base64",
+			encoding: "base64",
+			input:    base64.StdEncoding.EncodeToString([]byte("decoded text")),
+			want:     "decoded text",
+		},
+		{
+			name:     "BASE64 case insensitive",
+			encoding: "  BASE64  ",
+			input:    base64.StdEncoding.EncodeToString([]byte("case test")),
+			want:     "case test",
+		},
+		{
+			name:     "quoted-printable",
+			encoding: "quoted-printable",
+			input:    "hello =3D world",
+			want:     "hello = world",
+		},
+		{
+			name:     "7bit passthrough",
+			encoding: "7bit",
+			input:    "plain text",
+			want:     "plain text",
+		},
+		{
+			name:     "8bit passthrough",
+			encoding: "8bit",
+			input:    "plain text with ü",
+			want:     "plain text with ü",
+		},
+		{
+			name:     "empty encoding passthrough",
+			encoding: "",
+			input:    "no encoding",
+			want:     "no encoding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := decodeCTE(strings.NewReader(tt.input), tt.encoding)
+			data, err := readAll(reader)
+			if err != nil {
+				t.Fatalf("read error: %v", err)
+			}
+			if data != tt.want {
+				t.Errorf("decodeCTE(%q, %q) = %q, want %q", tt.input, tt.encoding, data, tt.want)
+			}
+		})
+	}
+}
+
+func readAll(r interface{ Read([]byte) (int, error) }) (string, error) {
+	var buf strings.Builder
+	tmp := make([]byte, 1024)
+	for {
+		n, err := r.Read(tmp)
+		if n > 0 {
+			buf.Write(tmp[:n])
+		}
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return buf.String(), err
+		}
+	}
+	return buf.String(), nil
 }

--- a/pkg/launcher/chat_console.go
+++ b/pkg/launcher/chat_console.go
@@ -164,10 +164,7 @@ func RunChatConsole(ctx context.Context, cfg *ChatConsoleConfig) error {
 	)
 
 	// --- 10. Welcome message ---
-	shortID := sess.ID()
-	if len(shortID) > 8 {
-		shortID = shortID[:8]
-	}
+	shortID := persistentsession.SafeShortID(sess.ID(), 16)
 
 	if isResumed {
 		// Friendly welcome back
@@ -415,10 +412,7 @@ func RunChatConsole(ctx context.Context, cfg *ChatConsoleConfig) error {
 					fmt.Printf("%sError:%s Failed to create new session: %v\n\n", "\033[31m", ColorReset, newErr)
 				} else {
 					sess = newResp.Session
-					shortID = sess.ID()
-					if len(shortID) > 8 {
-						shortID = shortID[:8]
-					}
+					shortID = persistentsession.SafeShortID(sess.ID(), 16)
 					fmt.Printf("%sFresh start!%s New session: %s\n\n", ColorGreen, ColorReset, shortID)
 				}
 			case input == "/help":

--- a/pkg/sandbox/incus.go
+++ b/pkg/sandbox/incus.go
@@ -130,20 +130,67 @@ func TemplateName(name string) string {
 }
 
 // SessionContainerName returns the full Incus container name for a session.
+// The session ID is sanitized to contain only alphanumeric and hyphen
+// characters (Incus requirement) and truncated to fit the 63-char limit.
 func SessionContainerName(sessionID string) string {
-	if len(sessionID) > 8 {
-		return SessionPrefix + sessionID[:8]
+	sanitized := sanitizeInstanceName(sessionID)
+	// Max Incus name = 63 chars. SessionPrefix is 10 chars, leaving 53.
+	// Use up to 40 chars from the sanitized ID for good uniqueness
+	// (channel session IDs like "email-direct-<addr>" need more room).
+	const maxSuffix = 40
+	if len(sanitized) > maxSuffix {
+		sanitized = sanitized[:maxSuffix]
 	}
-	return SessionPrefix + sessionID
+	// Trim trailing hyphens (invalid for Incus instance names)
+	sanitized = strings.TrimRight(sanitized, "-")
+	if sanitized == "" {
+		sanitized = "unknown"
+	}
+	return SessionPrefix + sanitized
+}
+
+// sanitizeInstanceName replaces characters that are invalid in Incus instance
+// names with hyphens and collapses consecutive hyphens. Incus allows only
+// lowercase alphanumeric characters and hyphens, and names must not start or
+// end with a hyphen.
+func sanitizeInstanceName(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	prevHyphen := true // treat start as hyphen to skip leading hyphens
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			prevHyphen = false
+		} else if !prevHyphen {
+			b.WriteByte('-')
+			prevHyphen = true
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
 }
 
 // FleetContainerName returns the full Incus container name for a fleet session.
 func FleetContainerName(planKey, agentKey, taskSlug string) string {
-	name := FleetPrefix + planKey + "-" + agentKey
+	name := FleetPrefix + sanitizeInstanceName(planKey) + "-" + sanitizeInstanceName(agentKey)
 	if taskSlug != "" {
-		name += "-" + taskSlug
+		name += "-" + sanitizeInstanceName(taskSlug)
 	}
+	// Enforce Incus max name length (63 chars)
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	name = strings.TrimRight(name, "-")
 	return name
+}
+
+// safeShortID truncates a session ID for display purposes without panicking
+// on short strings. Used in log messages where the full ID list is unavailable.
+func safeShortID(id string, maxLen int) string {
+	if len(id) <= maxLen {
+		return id
+	}
+	return id[:maxLen]
 }
 
 // SnapshotSource returns the snapshot source string for cloning.

--- a/pkg/sandbox/incus_test.go
+++ b/pkg/sandbox/incus_test.go
@@ -1,0 +1,210 @@
+package sandbox
+
+import (
+	"testing"
+)
+
+func TestSanitizeInstanceName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple alphanumeric", "abc123", "abc123"},
+		{"uppercase converted", "ABC123", "abc123"},
+		{"uuid passthrough", "a2a5b479-b03a-4662", "a2a5b479-b03a-4662"},
+		{"colons replaced", "email:direct:user", "email-direct-user"},
+		{"email address", "rafael.schardosin@sap.com", "rafael-schardosin-sap-com"},
+		{"consecutive special chars collapsed", "a::b@@c", "a-b-c"},
+		{"leading special chars stripped", "::abc", "abc"},
+		{"trailing special chars stripped", "abc::", "abc"},
+		{"mixed special chars", "email:direct:user@domain.com", "email-direct-user-domain-com"},
+		{"empty string", "", ""},
+		{"only special chars", ":::@@@...", ""},
+		{"hyphens preserved", "my-session-id", "my-session-id"},
+		{"spaces replaced", "hello world", "hello-world"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := sanitizeInstanceName(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeInstanceName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionContainerName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		sessionID string
+		want      string
+	}{
+		{
+			"uuid session (studio)",
+			"a2a5b479-b03a-4662-96aa-40aa8bade469",
+			// sanitized: a2a5b479-b03a-4662-96aa-40aa8bade469 (36 chars, fits in 40)
+			"astn-sess-a2a5b479-b03a-4662-96aa-40aa8bade469",
+		},
+		{
+			"email channel session",
+			"email:direct:rafael.schardosin@sap.com",
+			// sanitized: email-direct-rafael-schardosin-sap-com (38 chars, fits in 40)
+			"astn-sess-email-direct-rafael-schardosin-sap-com",
+		},
+		{
+			"telegram channel session",
+			"telegram:direct:8484406081",
+			// sanitized: telegram-direct-8484406081 (26 chars, fits in 40)
+			"astn-sess-telegram-direct-8484406081",
+		},
+		{
+			"short session ID",
+			"test",
+			"astn-sess-test",
+		},
+		{
+			"only invalid chars",
+			":::@@@",
+			"astn-sess-unknown",
+		},
+		{
+			"long email truncated",
+			"email:direct:a-very-long-username-that-exceeds-the-maximum@example.com",
+			// sanitized: email-direct-a-very-long-username-that-exceeds-the-maximum-example-com
+			// [:40] = "email-direct-a-very-long-username-that-e" → no trailing hyphen
+			"astn-sess-email-direct-a-very-long-username-that-e",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := SessionContainerName(tt.sessionID)
+			if got != tt.want {
+				t.Errorf("SessionContainerName(%q) = %q, want %q", tt.sessionID, got, tt.want)
+			}
+			// Verify the name only contains valid characters
+			for _, r := range got {
+				if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+					t.Errorf("SessionContainerName(%q) contains invalid character %q in result %q", tt.sessionID, string(r), got)
+				}
+			}
+			// Verify it doesn't end with a hyphen
+			if len(got) > 0 && got[len(got)-1] == '-' {
+				t.Errorf("SessionContainerName(%q) = %q ends with hyphen", tt.sessionID, got)
+			}
+		})
+	}
+}
+
+func TestSessionContainerNameDeterministic(t *testing.T) {
+	t.Parallel()
+	id := "email:direct:rafael.schardosin@sap.com"
+	name1 := SessionContainerName(id)
+	name2 := SessionContainerName(id)
+	if name1 != name2 {
+		t.Errorf("SessionContainerName is not deterministic: %q != %q", name1, name2)
+	}
+}
+
+func TestSessionContainerNameDistinct(t *testing.T) {
+	t.Parallel()
+	// Different email senders should get different container names
+	name1 := SessionContainerName("email:direct:alice@example.com")
+	name2 := SessionContainerName("email:direct:bob@example.com")
+	if name1 == name2 {
+		t.Errorf("different session IDs produced same container name: %q", name1)
+	}
+}
+
+func TestMatchContainerToSession(t *testing.T) {
+	t.Parallel()
+
+	sessions := map[string]bool{
+		"a2a5b479-b03a-4662-96aa-40aa8bade469":   true,
+		"email:direct:rafael.schardosin@sap.com": true,
+		"telegram:direct:8484406081":             true,
+	}
+
+	tests := []struct {
+		name          string
+		containerName string
+		want          string
+	}{
+		{
+			"matches uuid session",
+			SessionContainerName("a2a5b479-b03a-4662-96aa-40aa8bade469"),
+			"a2a5b479-b03a-4662-96aa-40aa8bade469",
+		},
+		{
+			"matches email session",
+			SessionContainerName("email:direct:rafael.schardosin@sap.com"),
+			"email:direct:rafael.schardosin@sap.com",
+		},
+		{
+			"matches telegram session",
+			SessionContainerName("telegram:direct:8484406081"),
+			"telegram:direct:8484406081",
+		},
+		{
+			"no match for unknown container",
+			"astn-sess-unknown-session-id",
+			"",
+		},
+		{
+			"no match for fleet container",
+			"astn-fleet-plan-agent",
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := matchContainerToSession(tt.containerName, sessions)
+			if got != tt.want {
+				t.Errorf("matchContainerToSession(%q) = %q, want %q", tt.containerName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFleetContainerName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		planKey  string
+		agentKey string
+		taskSlug string
+		wantPfx  string
+	}{
+		{"basic fleet name", "astonish", "researcher", "", "astn-fleet-astonish-researcher"},
+		{"with task slug", "plan", "agent", "task1", "astn-fleet-plan-agent-task1"},
+		{"special chars sanitized", "my:plan", "my@agent", "", "astn-fleet-my-plan-my-agent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FleetContainerName(tt.planKey, tt.agentKey, tt.taskSlug)
+			if got != tt.wantPfx {
+				t.Errorf("FleetContainerName(%q, %q, %q) = %q, want %q",
+					tt.planKey, tt.agentKey, tt.taskSlug, got, tt.wantPfx)
+			}
+			// Verify valid characters
+			for _, r := range got {
+				if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+					t.Errorf("FleetContainerName result %q contains invalid character %q", got, string(r))
+				}
+			}
+		})
+	}
+}

--- a/pkg/sandbox/lifecycle.go
+++ b/pkg/sandbox/lifecycle.go
@@ -314,7 +314,7 @@ func PruneOrphans(client *IncusClient, registry *SessionRegistry, existingSessio
 		}
 
 		// Orphaned — destroy
-		fmt.Printf("Pruning orphaned container %q (session %s)...\n", entry.ContainerName, entry.SessionID[:8])
+		fmt.Printf("Pruning orphaned container %q (session %s)...\n", entry.ContainerName, safeShortID(entry.SessionID, 16))
 
 		if client.InstanceExists(entry.ContainerName) {
 			if err := destroyOverlayContainer(client, entry.ContainerName); err != nil {
@@ -433,7 +433,8 @@ func PruneStaleOnStartup(client *IncusClient, registry *SessionRegistry, existin
 }
 
 // matchContainerToSession tries to find a session ID in existingSessionIDs
-// that matches an astn-sess-* container name by its 8-char prefix.
+// that matches an astn-sess-* container name. It derives the expected
+// container name for each session ID and compares.
 // Fleet containers (astn-fleet-*) use a different naming scheme that can't
 // be reversed to a session ID, so they return empty.
 func matchContainerToSession(containerName string, existingSessionIDs map[string]bool) string {
@@ -441,13 +442,8 @@ func matchContainerToSession(containerName string, existingSessionIDs map[string
 		return ""
 	}
 
-	prefix := strings.TrimPrefix(containerName, SessionPrefix)
-	if prefix == "" {
-		return ""
-	}
-
 	for sessionID := range existingSessionIDs {
-		if strings.HasPrefix(sessionID, prefix) {
+		if SessionContainerName(sessionID) == containerName {
 			return sessionID
 		}
 	}

--- a/pkg/session/file_store.go
+++ b/pkg/session/file_store.go
@@ -21,10 +21,11 @@ import (
 // FileStore implements ADK's session.Service interface with file-based persistence.
 // Sessions are stored as JSONL transcript files with a JSON metadata index.
 type FileStore struct {
-	baseDir  string // e.g. ~/.config/astonish/sessions/
-	index    *SessionIndex
-	mu       sync.RWMutex
-	sessions map[string]*fileSession // sessionID -> in-memory session (loaded on demand)
+	baseDir     string // e.g. ~/.config/astonish/sessions/
+	index       *SessionIndex
+	threadIndex *ThreadIndex
+	mu          sync.RWMutex
+	sessions    map[string]*fileSession // sessionID -> in-memory session (loaded on demand)
 
 	// RedactFunc, if set, sanitizes text before persisting to disk.
 	// Used to strip credential values from session transcripts.
@@ -49,12 +50,14 @@ func NewFileStore(baseDir string) (*FileStore, error) {
 	}
 
 	indexPath := filepath.Join(baseDir, "index.json")
+	threadIndexPath := filepath.Join(baseDir, "thread_index.json")
 	return &FileStore{
-		baseDir:   baseDir,
-		index:     NewSessionIndex(indexPath),
-		sessions:  make(map[string]*fileSession),
-		appState:  make(map[string]stateMap),
-		userState: make(map[string]map[string]stateMap),
+		baseDir:     baseDir,
+		index:       NewSessionIndex(indexPath),
+		threadIndex: NewThreadIndex(threadIndexPath),
+		sessions:    make(map[string]*fileSession),
+		appState:    make(map[string]stateMap),
+		userState:   make(map[string]map[string]stateMap),
 	}, nil
 }
 
@@ -241,6 +244,7 @@ func (s *FileStore) List(ctx context.Context, req *adksession.ListRequest) (*adk
 
 // Delete deletes a session by removing its transcript and index entry.
 // If the session has child sub-sessions, they are cascade-deleted as well.
+// Thread index entries pointing to this session are also removed.
 func (s *FileStore) Delete(ctx context.Context, req *adksession.DeleteRequest) error {
 	if req.AppName == "" || req.UserID == "" || req.SessionID == "" {
 		return fmt.Errorf("app_name, user_id, session_id are required, got app_name: %q, user_id: %q, session_id: %q",
@@ -266,6 +270,11 @@ func (s *FileStore) Delete(ctx context.Context, req *adksession.DeleteRequest) e
 	// Remove transcript file
 	transcriptPath := filepath.Join(s.baseDir, req.AppName, req.UserID, req.SessionID+".jsonl")
 	os.Remove(transcriptPath) // ignore error if file doesn't exist
+
+	// Remove thread index entries that point to this session (best-effort)
+	if err := s.threadIndex.RemoveSession(req.SessionID); err != nil {
+		slog.Warn("failed to clean up thread index", "session", req.SessionID, "error", err)
+	}
 
 	// Remove from index (cascades children automatically)
 	return s.index.Remove(req.SessionID)
@@ -368,7 +377,8 @@ func (s *FileStore) ResolveSessionID(partial string) (string, error) {
 	case 1:
 		return matches[0], nil
 	default:
-		return "", fmt.Errorf("ambiguous session ID %q matches %d sessions", partial, len(matches))
+		sort.Strings(matches)
+		return "", fmt.Errorf("ambiguous session ID %q matches %d sessions:\n  %s", partial, len(matches), strings.Join(matches, "\n  "))
 	}
 }
 
@@ -421,6 +431,12 @@ func (s *FileStore) BaseDir() string {
 // This is used by the trace API to walk child sessions.
 func (s *FileStore) Index() *SessionIndex {
 	return s.index
+}
+
+// ThreadIndex returns the underlying ThreadIndex for direct access.
+// Used by the email channel to map Message-IDs to session keys.
+func (s *FileStore) ThreadIndex() *ThreadIndex {
+	return s.threadIndex
 }
 
 // ReadTranscriptEvents reads all events from a session's transcript file.

--- a/pkg/session/shortid.go
+++ b/pkg/session/shortid.go
@@ -1,0 +1,57 @@
+package session
+
+// ShortID returns the shortest prefix of id that uniquely identifies it
+// among allIDs. The minimum returned length is 8 characters (or the full
+// ID if shorter). If the ID cannot be uniquely shortened (e.g., it is a
+// prefix of another ID), the full ID is returned.
+func ShortID(id string, allIDs []string) string {
+	const minLen = 8
+
+	// Start from minLen and grow until the prefix is unique
+	for prefixLen := minLen; prefixLen < len(id); prefixLen++ {
+		prefix := id[:prefixLen]
+		unique := true
+		for _, other := range allIDs {
+			if other == id {
+				continue
+			}
+			if len(other) >= prefixLen && other[:prefixLen] == prefix {
+				unique = false
+				break
+			}
+		}
+		if unique {
+			return prefix
+		}
+	}
+
+	// Full ID is needed for uniqueness (or ID is <= minLen)
+	if len(id) <= minLen {
+		return id
+	}
+	return id
+}
+
+// ShortIDs computes the shortest unique prefix for each ID in the list.
+// Returns a map from full ID to its shortest unique display string.
+func ShortIDs(allIDs []string) map[string]string {
+	result := make(map[string]string, len(allIDs))
+	for _, id := range allIDs {
+		result[id] = ShortID(id, allIDs)
+	}
+	return result
+}
+
+// SafeShortID returns a shortened session ID for contexts where the full
+// list of IDs is not available (log messages, single-session displays).
+// It truncates to maxLen characters, which is more generous than the old
+// 8-char limit to accommodate structured IDs like "email:direct:user@...".
+func SafeShortID(id string, maxLen int) string {
+	if maxLen <= 0 {
+		maxLen = 16
+	}
+	if len(id) <= maxLen {
+		return id
+	}
+	return id[:maxLen]
+}

--- a/pkg/session/shortid_test.go
+++ b/pkg/session/shortid_test.go
@@ -1,0 +1,168 @@
+package session
+
+import (
+	"testing"
+)
+
+func TestShortID(t *testing.T) {
+	tests := []struct {
+		name   string
+		id     string
+		allIDs []string
+		want   string
+	}{
+		{
+			name:   "unique at min length",
+			id:     "abcdefghijklmnop",
+			allIDs: []string{"abcdefghijklmnop", "zyxwvuts12345678"},
+			want:   "abcdefgh", // 8-char min is sufficient
+		},
+		{
+			name:   "needs longer prefix",
+			id:     "email:direct:alice@example.com",
+			allIDs: []string{"email:direct:alice@example.com", "email:direct:bob@example.com"},
+			want:   "email:direct:a", // diverges at char 14
+		},
+		{
+			name:   "identical prefix needs more chars",
+			id:     "abcdefghij_first",
+			allIDs: []string{"abcdefghij_first", "abcdefghij_second"},
+			want:   "abcdefghij_f",
+		},
+		{
+			name:   "single ID returns min prefix",
+			id:     "abcdefghijklmnop",
+			allIDs: []string{"abcdefghijklmnop"},
+			want:   "abcdefgh",
+		},
+		{
+			name:   "short ID returned as-is",
+			id:     "abc",
+			allIDs: []string{"abc", "xyz"},
+			want:   "abc",
+		},
+		{
+			name:   "exactly min length",
+			id:     "abcdefgh",
+			allIDs: []string{"abcdefgh", "zyxwvuts"},
+			want:   "abcdefgh",
+		},
+		{
+			name:   "full ID needed when one is prefix of another",
+			id:     "abcdefghij",
+			allIDs: []string{"abcdefghij", "abcdefghijk"},
+			want:   "abcdefghij",
+		},
+		{
+			name:   "empty list",
+			id:     "abcdefghij",
+			allIDs: []string{},
+			want:   "abcdefgh",
+		},
+		{
+			name:   "channel session IDs distinguished",
+			id:     "telegram:group:12345",
+			allIDs: []string{"telegram:group:12345", "telegram:group:67890"},
+			want:   "telegram:group:1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ShortID(tt.id, tt.allIDs)
+			if got != tt.want {
+				t.Errorf("ShortID(%q, %v) = %q, want %q", tt.id, tt.allIDs, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShortIDs(t *testing.T) {
+	allIDs := []string{
+		"email:direct:alice@example.com",
+		"email:direct:bob@example.com",
+		"telegram:group:12345",
+		"abc123defgh",
+	}
+
+	result := ShortIDs(allIDs)
+
+	if len(result) != len(allIDs) {
+		t.Fatalf("ShortIDs returned %d entries, want %d", len(result), len(allIDs))
+	}
+
+	// All short IDs should be present
+	for _, id := range allIDs {
+		if _, ok := result[id]; !ok {
+			t.Errorf("ShortIDs missing entry for %q", id)
+		}
+	}
+
+	// email IDs should be different from each other
+	aliceShort := result["email:direct:alice@example.com"]
+	bobShort := result["email:direct:bob@example.com"]
+	if aliceShort == bobShort {
+		t.Errorf("alice and bob got same short ID: %q", aliceShort)
+	}
+
+	// telegram ID should be short (unique at min length)
+	teleShort := result["telegram:group:12345"]
+	if len(teleShort) > 8 {
+		t.Errorf("telegram short ID longer than expected: %q (len %d)", teleShort, len(teleShort))
+	}
+}
+
+func TestSafeShortID(t *testing.T) {
+	tests := []struct {
+		name   string
+		id     string
+		maxLen int
+		want   string
+	}{
+		{
+			name:   "longer than max",
+			id:     "email:direct:alice@example.com",
+			maxLen: 16,
+			want:   "email:direct:ali",
+		},
+		{
+			name:   "shorter than max",
+			id:     "short",
+			maxLen: 16,
+			want:   "short",
+		},
+		{
+			name:   "exact max length",
+			id:     "abcdefghijklmnop",
+			maxLen: 16,
+			want:   "abcdefghijklmnop",
+		},
+		{
+			name:   "zero maxLen defaults to 16",
+			id:     "email:direct:alice@example.com",
+			maxLen: 0,
+			want:   "email:direct:ali",
+		},
+		{
+			name:   "negative maxLen defaults to 16",
+			id:     "email:direct:alice@example.com",
+			maxLen: -5,
+			want:   "email:direct:ali",
+		},
+		{
+			name:   "empty string",
+			id:     "",
+			maxLen: 16,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SafeShortID(tt.id, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("SafeShortID(%q, %d) = %q, want %q", tt.id, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/session/thread_index.go
+++ b/pkg/session/thread_index.go
@@ -1,0 +1,165 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// ThreadIndex manages a persistent mapping from email Message-ID values to
+// session keys. This enables per-thread email sessions: new emails create new
+// sessions, and replies (identified by In-Reply-To / References headers) are
+// routed to the same session as the original thread.
+//
+// The index file is stored alongside the session index as thread_index.json.
+// It follows the same patterns: sync.Mutex for concurrency, load-modify-save
+// for every mutation, and atomicWrite for crash safety.
+type ThreadIndex struct {
+	path string
+	mu   sync.Mutex
+}
+
+// ThreadIndexData is the on-disk representation of the thread index.
+type ThreadIndexData struct {
+	Version int               `json:"version"`
+	Threads map[string]string `json:"threads"` // Message-ID -> session key
+}
+
+// NewThreadIndex creates a ThreadIndex backed by the given file path.
+func NewThreadIndex(path string) *ThreadIndex {
+	return &ThreadIndex{path: path}
+}
+
+// Lookup returns the session key associated with a Message-ID, if any.
+func (t *ThreadIndex) Lookup(messageID string) (string, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	data, err := t.loadUnsafe()
+	if err != nil {
+		return "", false
+	}
+
+	sessionKey, ok := data.Threads[messageID]
+	return sessionKey, ok
+}
+
+// LookupChain searches a list of Message-IDs (typically In-Reply-To followed
+// by References, newest first) and returns the session key for the first match.
+// This provides fallback: if In-Reply-To isn't indexed, an older Reference
+// from the chain may still resolve.
+func (t *ThreadIndex) LookupChain(messageIDs []string) (string, bool) {
+	if len(messageIDs) == 0 {
+		return "", false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	data, err := t.loadUnsafe()
+	if err != nil {
+		return "", false
+	}
+
+	for _, id := range messageIDs {
+		if sessionKey, ok := data.Threads[id]; ok {
+			return sessionKey, true
+		}
+	}
+	return "", false
+}
+
+// Associate maps one or more Message-IDs to a session key. Existing entries
+// for the same Message-ID are overwritten. This is used to index both inbound
+// (received) and outbound (sent) Message-IDs.
+func (t *ThreadIndex) Associate(messageIDs []string, sessionKey string) error {
+	if len(messageIDs) == 0 || sessionKey == "" {
+		return nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	data, err := t.loadUnsafe()
+	if err != nil {
+		return err
+	}
+
+	for _, id := range messageIDs {
+		if id != "" {
+			data.Threads[id] = sessionKey
+		}
+	}
+
+	return t.saveUnsafe(data)
+}
+
+// RemoveSession removes all thread mappings that point to the given session key.
+// Called when a session is deleted (e.g., /new command) to clean up stale entries.
+func (t *ThreadIndex) RemoveSession(sessionKey string) error {
+	if sessionKey == "" {
+		return nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	data, err := t.loadUnsafe()
+	if err != nil {
+		return err
+	}
+
+	changed := false
+	for msgID, key := range data.Threads {
+		if key == sessionKey {
+			delete(data.Threads, msgID)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+	return t.saveUnsafe(data)
+}
+
+// Load reads the full index from disk.
+func (t *ThreadIndex) Load() (*ThreadIndexData, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.loadUnsafe()
+}
+
+// loadUnsafe reads the index without locking (caller must hold the lock).
+func (t *ThreadIndex) loadUnsafe() (*ThreadIndexData, error) {
+	raw, err := os.ReadFile(t.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &ThreadIndexData{
+				Version: 1,
+				Threads: make(map[string]string),
+			}, nil
+		}
+		return nil, fmt.Errorf("failed to read thread index: %w", err)
+	}
+
+	var data ThreadIndexData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("failed to parse thread index: %w", err)
+	}
+
+	if data.Threads == nil {
+		data.Threads = make(map[string]string)
+	}
+	return &data, nil
+}
+
+// saveUnsafe writes the index to disk atomically (caller must hold the lock).
+func (t *ThreadIndex) saveUnsafe(data *ThreadIndexData) error {
+	raw, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize thread index: %w", err)
+	}
+	return atomicWrite(t.path, raw, 0644)
+}

--- a/pkg/session/thread_index_test.go
+++ b/pkg/session/thread_index_test.go
@@ -1,0 +1,221 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestThreadIndex_LookupEmpty(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	_, ok := idx.Lookup("<nonexistent@example.com>")
+	if ok {
+		t.Error("expected Lookup to return false on empty index")
+	}
+}
+
+func TestThreadIndex_AssociateAndLookup(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	sessionKey := "email:direct:alice@example.com-a1b2c3d4"
+	msgID := "<msg001@example.com>"
+
+	if err := idx.Associate([]string{msgID}, sessionKey); err != nil {
+		t.Fatalf("Associate failed: %v", err)
+	}
+
+	got, ok := idx.Lookup(msgID)
+	if !ok {
+		t.Fatal("expected Lookup to return true after Associate")
+	}
+	if got != sessionKey {
+		t.Errorf("Lookup = %q, want %q", got, sessionKey)
+	}
+}
+
+func TestThreadIndex_AssociateMultiple(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	sessionKey := "email:direct:alice@example.com-a1b2c3d4"
+	ids := []string{"<msg001@ex.com>", "<msg002@ex.com>", "<reply001@astonish.com>"}
+
+	if err := idx.Associate(ids, sessionKey); err != nil {
+		t.Fatalf("Associate failed: %v", err)
+	}
+
+	for _, id := range ids {
+		got, ok := idx.Lookup(id)
+		if !ok {
+			t.Errorf("Lookup(%q) returned false", id)
+		}
+		if got != sessionKey {
+			t.Errorf("Lookup(%q) = %q, want %q", id, got, sessionKey)
+		}
+	}
+}
+
+func TestThreadIndex_LookupChain(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	sessionKey := "email:direct:bob@example.com-deadbeef"
+	if err := idx.Associate([]string{"<original@example.com>"}, sessionKey); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lookup chain: In-Reply-To first (not indexed), then References (has match)
+	chain := []string{"<reply-unknown@example.com>", "<original@example.com>"}
+	got, ok := idx.LookupChain(chain)
+	if !ok {
+		t.Fatal("expected LookupChain to find a match")
+	}
+	if got != sessionKey {
+		t.Errorf("LookupChain = %q, want %q", got, sessionKey)
+	}
+}
+
+func TestThreadIndex_LookupChain_FirstMatch(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	session1 := "email:direct:alice@example.com-1111"
+	session2 := "email:direct:alice@example.com-2222"
+	_ = idx.Associate([]string{"<msg-A@ex.com>"}, session1)
+	_ = idx.Associate([]string{"<msg-B@ex.com>"}, session2)
+
+	// Chain should return first match
+	chain := []string{"<msg-B@ex.com>", "<msg-A@ex.com>"}
+	got, ok := idx.LookupChain(chain)
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if got != session2 {
+		t.Errorf("LookupChain = %q, want %q (first match)", got, session2)
+	}
+}
+
+func TestThreadIndex_LookupChain_Empty(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	_, ok := idx.LookupChain(nil)
+	if ok {
+		t.Error("expected empty chain to return false")
+	}
+	_, ok = idx.LookupChain([]string{})
+	if ok {
+		t.Error("expected empty chain to return false")
+	}
+}
+
+func TestThreadIndex_RemoveSession(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	session1 := "email:direct:alice@example.com-1111"
+	session2 := "email:direct:bob@example.com-2222"
+
+	_ = idx.Associate([]string{"<a1@ex.com>", "<a2@ex.com>"}, session1)
+	_ = idx.Associate([]string{"<b1@ex.com>"}, session2)
+
+	// Remove session1 — should remove both a1 and a2, leave b1
+	if err := idx.RemoveSession(session1); err != nil {
+		t.Fatalf("RemoveSession failed: %v", err)
+	}
+
+	if _, ok := idx.Lookup("<a1@ex.com>"); ok {
+		t.Error("expected <a1@ex.com> to be removed")
+	}
+	if _, ok := idx.Lookup("<a2@ex.com>"); ok {
+		t.Error("expected <a2@ex.com> to be removed")
+	}
+	if got, ok := idx.Lookup("<b1@ex.com>"); !ok || got != session2 {
+		t.Errorf("expected <b1@ex.com> to remain mapped to %q", session2)
+	}
+}
+
+func TestThreadIndex_RemoveSession_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	// Removing from empty index should not error
+	if err := idx.RemoveSession("nonexistent"); err != nil {
+		t.Errorf("RemoveSession on empty index: %v", err)
+	}
+}
+
+func TestThreadIndex_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thread_index.json")
+
+	// Write with first index instance
+	idx1 := NewThreadIndex(path)
+	_ = idx1.Associate([]string{"<persist@ex.com>"}, "email:direct:test-persist")
+
+	// Read with a fresh index instance (simulates daemon restart)
+	idx2 := NewThreadIndex(path)
+	got, ok := idx2.Lookup("<persist@ex.com>")
+	if !ok {
+		t.Fatal("expected persisted entry to survive reload")
+	}
+	if got != "email:direct:test-persist" {
+		t.Errorf("got %q after reload", got)
+	}
+}
+
+func TestThreadIndex_RemoveSession_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thread_index.json")
+
+	idx := NewThreadIndex(path)
+	_ = idx.Associate([]string{"<del@ex.com>"}, "email:direct:to-delete")
+	_ = idx.RemoveSession("email:direct:to-delete")
+
+	// Reload and verify it's gone
+	idx2 := NewThreadIndex(path)
+	if _, ok := idx2.Lookup("<del@ex.com>"); ok {
+		t.Error("expected removed entry to be gone after reload")
+	}
+}
+
+func TestThreadIndex_AssociateEmpty(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	// Empty slices and keys should be no-ops
+	if err := idx.Associate(nil, "session"); err != nil {
+		t.Errorf("Associate(nil) = %v", err)
+	}
+	if err := idx.Associate([]string{}, "session"); err != nil {
+		t.Errorf("Associate([]) = %v", err)
+	}
+	if err := idx.Associate([]string{"<id>"}, ""); err != nil {
+		t.Errorf("Associate with empty session key = %v", err)
+	}
+
+	// Verify nothing was written
+	_, err := os.Stat(filepath.Join(dir, "thread_index.json"))
+	if err == nil {
+		t.Error("expected no file to be created for empty operations")
+	}
+}
+
+func TestThreadIndex_OverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	idx := NewThreadIndex(filepath.Join(dir, "thread_index.json"))
+
+	_ = idx.Associate([]string{"<msg@ex.com>"}, "session-old")
+	_ = idx.Associate([]string{"<msg@ex.com>"}, "session-new")
+
+	got, ok := idx.Lookup("<msg@ex.com>")
+	if !ok {
+		t.Fatal("expected lookup to succeed")
+	}
+	if got != "session-new" {
+		t.Errorf("expected overwrite, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- **Per-thread email sessions**: Each email thread now gets its own agent session instead of sharing one session per sender. Uses RFC 2822 Message-ID / In-Reply-To / References headers for thread tracking with a persistent thread index (`thread_index.json`). New emails create new sessions; replies chain to the original thread. Outbound Message-IDs are also indexed so replies to our responses chain correctly.

- **Email body CTE decoding**: Fix pre-existing bug where `Content-Transfer-Encoding: base64` and `quoted-printable` were not decoded on inbound emails, causing reply bodies to appear as raw base64 strings instead of readable text.

- **Config hot-reload**: Watch `config.yaml` for changes and apply allowlist updates at runtime without restarting the daemon. Uses fsnotify with 1500ms debounce. Targeted allowlist-only updates when possible; full channel reload for structural changes.

- **Sandbox container name sanitization**: Session IDs containing colons, dots, and `@` (from email/telegram channels) are now sanitized for Incus container names. Uses human-readable sanitization with deterministic matching.

- **Session ID display**: Replace blind 8-char truncation with minimum unique prefix algorithm (`ShortID`) and safe truncation (`SafeShortID`) to prevent display collisions and panics on short IDs.

## Files Changed (27 files, +2338/-59)

### Per-thread email sessions
- `pkg/session/thread_index.go` — **NEW**: Persistent `ThreadIndex` (Message-ID → session key mapping)
- `pkg/session/thread_index_test.go` — **NEW**: 12 tests
- `pkg/channels/email/email.go` — Thread-aware routing via `resolveThreadSession()`, outbound Message-ID indexing in `Send()`
- `pkg/channels/email/email_test.go` — 8 new threading tests
- `pkg/channels/channel.go` — Added `MessageID` field to `InboundMessage`
- `pkg/channels/router.go` — Use `ThreadID` as session key when set (email threads)
- `pkg/channels/router_test.go` — 2 new tests for ThreadID override
- `pkg/channels/manager.go` — Thread info passthrough
- `pkg/email/client.go` — Added `MessageID`/`InReplyTo` to `MessageSummary`
- `pkg/email/imap.go` — Extract `References` header; populate `MessageID`/`InReplyTo` in `ListMessages`
- `pkg/session/file_store.go` — Thread index wiring + cleanup on session delete
- `pkg/daemon/run.go` — Inject thread index into email channel at startup

### Email CTE decoding fix
- `pkg/email/parser.go` — Added `decodeCTE()` helper; applied at all 5 read sites (multipart + non-multipart)
- `pkg/email/parser_test.go` — 12 new tests (base64, quoted-printable, multipart, 7bit)

### Config hot-reload
- `pkg/daemon/config_watcher.go` — **NEW**: fsnotify watcher with debounce and diff logic
- `pkg/daemon/config_watcher_test.go` — **NEW**: 18 tests
- `pkg/channels/channel.go` — `AllowlistUpdater` interface
- `pkg/channels/email/email.go` — Thread-safe `UpdateAllowlist()` with seenIDs clear
- `pkg/channels/telegram/telegram.go` — Thread-safe `UpdateAllowlist()`
- `pkg/channels/manager.go` — `UpdateAllowlists()` method
- `pkg/daemon/run.go` — Watcher startup wiring

### Container name sanitization
- `pkg/sandbox/incus.go` — `sanitizeInstanceName()`, hardened `SessionContainerName()`/`FleetContainerName()`
- `pkg/sandbox/lifecycle.go` — Deterministic `matchContainerToSession()` rewrite
- `pkg/sandbox/incus_test.go` — **NEW**: 27 tests
- `cmd/astonish/sandbox.go` — Comment update

### Session ID display
- `pkg/session/shortid.go` — **NEW**: `ShortID`/`ShortIDs`/`SafeShortID`
- `pkg/session/shortid_test.go` — **NEW**: 15 tests
- `cmd/astonish/sessions.go` — Unique prefix display + improved ambiguous error
- `pkg/api/chat_handlers.go` — `SafeShortID` for status display
- `pkg/launcher/chat_console.go` — `SafeShortID` for console display
- `pkg/sandbox/lifecycle.go` — Fix unguarded `[:8]` panic
- `pkg/channels/fleet_commands.go` — Fix unguarded `[:8]` panic

## Testing

- 94 new tests across 7 test files
- All existing tests pass
- `go build ./...` clean
- `golangci-lint run` — 0 issues