### PR TITLE
fix: return empty object for nil tool parameters in OpenAI-compatible provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/pkg/provider/openai/openai.go
+++ b/pkg/provider/openai/openai.go
@@ -706,7 +706,7 @@ func wrapOpenAIError(err error) error {
 // through JSON to get a mutable map.
 func sanitizeToolParams(params any) any {
 	if params == nil {
-		return params
+		return map[string]any{"type": "object", "properties": map[string]any{}}
 	}
 
 	m, ok := params.(map[string]any)


### PR DESCRIPTION
When a tool declaration has no parameters, sanitizeToolParams was returning nil, which serializes to null in the JSON request body.
  Strict OpenAI-compatible backends (such as proxies routing to LiteLLM) reject this with a 400 error:

  `None is not of type 'object' - 'config.modules.prompt_templating.prompt.tools[0].function.parameters'`

  The OpenAI spec requires parameters to be a JSON object, not null. This fix returns {"type": "object", "properties": {}} when params is nil, which is the correct empty schema and is accepted by all tested backends.

  Root cause: Tool declarations without parameters (no-arg tools) set ParametersJsonSchema to nil. The sanitizer passed nil straight through, resulting in "parameters": null in the outgoing request.