### PR TITLE
fix: use os.OpenRoot to prevent symlink TOCTOU in skill install

### DIFF
--- a/pkg/api/skills_handlers.go
+++ b/pkg/api/skills_handlers.go
@@ -1153,6 +1153,16 @@ func InstallSkillHandler(w http.ResponseWriter, r *http.Request) {
 	var totalSize int64
 	skillDir := filepath.Join(tmpDir, slug)
 
+	// Use os.OpenRoot to scope all file reads to skillDir, preventing symlink
+	// TOCTOU traversal attacks (gosec G122).
+	skillRoot, err := os.OpenRoot(skillDir)
+	if err != nil {
+		slog.Error("failed to open skill directory root", "dir", skillDir, "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to read skill files")
+		return
+	}
+	defer skillRoot.Close()
+
 	err = filepath.WalkDir(skillDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return err
@@ -1190,7 +1200,7 @@ func InstallSkillHandler(w http.ResponseWriter, r *http.Request) {
 			return fmt.Errorf("file count exceeds %d limit", maxInstallFiles)
 		}
 
-		content, err := os.ReadFile(path)
+		content, err := skillRoot.ReadFile(rel)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes golangci-lint failure (gosec G122) that blocks releases.

Replaces `os.ReadFile(path)` inside `filepath.WalkDir` callback with `os.Root`-scoped reads via `os.OpenRoot`. This eliminates the TOCTOU race window between path resolution and file open.

The `os.OpenRoot` API (Go 1.24+) ensures all file operations are confined to the skill directory, preventing symlink traversal even if an attacker modifies the temp directory concurrently.

**Before:** `os.ReadFile(path)` — race-prone, flagged by gosec G122
**After:** `skillRoot.ReadFile(rel)` — root-scoped, no symlink escape possible