### PR TITLE
fix: make Bootstrap() idempotent to handle interrupted setup

### DIFF
--- a/cmd/astonish/setup.go
+++ b/cmd/astonish/setup.go
@@ -72,6 +72,13 @@ func handleSetupCommand() error {
 			}
 			return err
 		}
+		// Save config immediately after backend setup. This ensures that if the
+		// user aborts during provider configuration (the next step), the backend
+		// choice (sqlite/postgres) is persisted. On next run, the wizard won't
+		// re-enter deployment mode setup and won't re-run Bootstrap.
+		if err := config.SaveAppConfig(cfg); err != nil {
+			return fmt.Errorf("error saving config after backend setup: %w", err)
+		}
 	}
 
 	// Make provider setup optional (like web search tools).

--- a/pkg/store/sqlitestore/bootstrap.go
+++ b/pkg/store/sqlitestore/bootstrap.go
@@ -25,7 +25,10 @@ type BootstrapConfig struct {
 // Bootstrap creates the first user, organization, and team for a fresh installation.
 // It provisions the org and team databases and creates all initial records.
 //
-// This should only be called when NeedsBootstrap() returns true.
+// This function is idempotent: if interrupted mid-way and re-run with the same
+// parameters, it will skip steps that have already completed and continue from
+// where it left off. This handles the case where setup is interrupted (e.g.,
+// user presses Ctrl+C after the user is created but before org/team setup).
 func (s *SQLiteStore) Bootstrap(ctx context.Context, cfg BootstrapConfig) error {
 	// Validate inputs
 	if cfg.Email == "" || cfg.Password == "" {
@@ -47,74 +50,95 @@ func (s *SQLiteStore) Bootstrap(ctx context.Context, cfg BootstrapConfig) error 
 		cfg.DisplayName = cfg.Email
 	}
 
-	// Hash password
-	hash, err := bcrypt.GenerateFromPassword([]byte(cfg.Password), bcrypt.DefaultCost)
-	if err != nil {
-		return fmt.Errorf("hash password: %w", err)
-	}
-
 	now := time.Now()
-	userID := uuid.New().String()
-	orgID := uuid.New().String()
 
-	// Create user
-	user := &store.User{
-		ID:           userID,
-		Email:        cfg.Email,
-		DisplayName:  cfg.DisplayName,
-		PasswordHash: string(hash),
-		PlatformRole: "superadmin",
-		Status:       "active",
-		CreatedAt:    now,
+	// Step 1: Create user (or retrieve existing one by email)
+	var userID string
+	existingUser, err := s.Users().GetByEmail(ctx, cfg.Email)
+	if err != nil {
+		return fmt.Errorf("check existing user: %w", err)
 	}
-	if err := s.Users().Create(ctx, user); err != nil {
-		return fmt.Errorf("create user: %w", err)
+	if existingUser != nil {
+		userID = existingUser.ID
+	} else {
+		hash, err := bcrypt.GenerateFromPassword([]byte(cfg.Password), bcrypt.DefaultCost)
+		if err != nil {
+			return fmt.Errorf("hash password: %w", err)
+		}
+		userID = uuid.New().String()
+		user := &store.User{
+			ID:           userID,
+			Email:        cfg.Email,
+			DisplayName:  cfg.DisplayName,
+			PasswordHash: string(hash),
+			PlatformRole: "superadmin",
+			Status:       "active",
+			CreatedAt:    now,
+		}
+		if err := s.Users().Create(ctx, user); err != nil {
+			return fmt.Errorf("create user: %w", err)
+		}
 	}
 
-	// Create organization
-	org := &store.Organization{
-		ID:        orgID,
-		Name:      cfg.OrgName,
-		Slug:      cfg.OrgSlug,
-		CreatedAt: now,
+	// Step 2: Create organization (or retrieve existing one by slug)
+	var orgID string
+	existingOrg, err := s.Organizations().GetBySlug(ctx, cfg.OrgSlug)
+	if err != nil {
+		return fmt.Errorf("check existing org: %w", err)
 	}
-	if err := s.Organizations().Create(ctx, org); err != nil {
-		return fmt.Errorf("create organization: %w", err)
+	if existingOrg != nil {
+		orgID = existingOrg.ID
+	} else {
+		orgID = uuid.New().String()
+		org := &store.Organization{
+			ID:        orgID,
+			Name:      cfg.OrgName,
+			Slug:      cfg.OrgSlug,
+			CreatedAt: now,
+		}
+		if err := s.Organizations().Create(ctx, org); err != nil {
+			return fmt.Errorf("create organization: %w", err)
+		}
 	}
 
-	// Create membership (owner role)
+	// Step 3: Create membership (INSERT OR REPLACE — already idempotent)
 	if err := s.Organizations().AddMember(ctx, userID, orgID, "owner"); err != nil {
 		return fmt.Errorf("add org membership: %w", err)
 	}
 
-	// Provision the org's data directory and database
+	// Step 4: Provision org data directory and database (idempotent — uses MkdirAll + migrate)
 	if err := s.ProvisionOrg(ctx, orgID, cfg.OrgSlug); err != nil {
 		return fmt.Errorf("provision org: %w", err)
 	}
 
-	// Get the org data store and provision team + personal schemas
+	// Step 5: Open org store and create team if needed
 	orgStore, err := s.ForOrg(cfg.OrgSlug)
 	if err != nil {
 		return fmt.Errorf("open org store: %w", err)
 	}
 
-	// Create team in the org database
-	team := &store.Team{
-		ID:        uuid.New().String(),
-		Name:      cfg.TeamName,
-		Slug:      cfg.TeamSlug,
-		CreatedAt: now,
+	existingTeam, err := orgStore.Teams().GetTeamBySlug(ctx, cfg.TeamSlug)
+	if err != nil {
+		return fmt.Errorf("check existing team: %w", err)
 	}
-	if err := orgStore.Teams().CreateTeam(ctx, team); err != nil {
-		return fmt.Errorf("create team: %w", err)
+	if existingTeam == nil {
+		team := &store.Team{
+			ID:        uuid.New().String(),
+			Name:      cfg.TeamName,
+			Slug:      cfg.TeamSlug,
+			CreatedAt: now,
+		}
+		if err := orgStore.Teams().CreateTeam(ctx, team); err != nil {
+			return fmt.Errorf("create team: %w", err)
+		}
 	}
 
-	// Provision the team database
+	// Step 6: Provision team database (idempotent — uses MkdirAll + migrate)
 	if err := orgStore.ProvisionTeam(ctx, cfg.TeamSlug); err != nil {
 		return fmt.Errorf("provision team: %w", err)
 	}
 
-	// Provision personal database for the user
+	// Step 7: Provision personal database (idempotent — uses MkdirAll + migrate)
 	if err := orgStore.ProvisionPersonalSchema(ctx, userID); err != nil {
 		return fmt.Errorf("provision personal schema: %w", err)
 	}


### PR DESCRIPTION
## Problem

If the user interrupts `astonish setup` (Ctrl+C) after the database is created but before the full process completes, re-running setup fails with:

```
✗ Bootstrap failed: create user: constraint failed: UNIQUE constraint failed: users.email (2067)
```

The only recovery was to manually delete the SQLite database file.

## Root Cause

Two issues combined:

1. **`Bootstrap()` was not idempotent** — it blindly INSERTs user/org/team records without checking if they already exist from a prior interrupted run.

2. **Config saved too late** — the config file (with `Backend: "sqlite"`) was only written at the END of the full setup wizard. If the user aborted during provider configuration (the step after backend setup), the config remained empty. On next run, the wizard re-entered deployment mode setup and called Bootstrap() again with the same email.

## Fix

1. **`Bootstrap()` is now fully idempotent** — each step checks for existing entities:
   - User: looks up by email, reuses existing ID if found
   - Org: looks up by slug, reuses existing ID if found  
   - Team: looks up by slug, skips creation if found
   - Membership (`INSERT OR REPLACE`), ProvisionOrg/Team/Personal (`MkdirAll` + `migrate`): already idempotent

2. **Config saved immediately after backend setup** — before provider configuration. If the user aborts during provider setup, the backend choice is already persisted and the next run skips directly to provider configuration.

## Testing

- `go build ./...` passes
- `golangci-lint run` passes (0 issues)