### PR TITLE
feat(email): Microsoft Graph OAuth provider for Microsoft 365 email

### DIFF
--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -1338,6 +1338,7 @@ func RegisterRoutes(router *mux.Router, svc *store.Services, backend store.Platf
 
 		// Channel adapter management (superadmin only)
 		router.HandleFunc("/api/platform/admin/channels", PlatformAdminListChannelsHandler).Methods("GET")
+		router.HandleFunc("/api/platform/admin/channels/email/test", PlatformAdminTestEmailHandler).Methods("POST")
 		router.HandleFunc("/api/platform/admin/channels/{type}", PlatformAdminSaveChannelHandler).Methods("PUT")
 		router.HandleFunc("/api/platform/admin/channels/{type}", PlatformAdminDeleteChannelHandler).Methods("DELETE")
 

--- a/pkg/api/platform_admin_handlers.go
+++ b/pkg/api/platform_admin_handlers.go
@@ -1114,3 +1114,18 @@ func SetPlatformSecrets(s platformSecrets) {
 func getPlatformSecrets() platformSecrets {
 	return platformSecretsInstance
 }
+
+// PlatformSecretWriter is an exported interface for writing platform secrets.
+// Used by the daemon to persist rotated OAuth tokens.
+type PlatformSecretWriter interface {
+	SetSecret(key, value string) error
+}
+
+// GetPlatformSecrets returns the platform secrets store as a PlatformSecretWriter,
+// or nil if unavailable. Used by external packages (e.g. daemon) for token rotation.
+func GetPlatformSecrets() PlatformSecretWriter {
+	if platformSecretsInstance == nil {
+		return nil
+	}
+	return platformSecretsInstance
+}

--- a/pkg/api/platform_channels_handlers.go
+++ b/pkg/api/platform_channels_handlers.go
@@ -579,6 +579,8 @@ func GetPlatformChannelSettings(ctx context.Context) *store.PlatformChannelSetti
 
 // PlatformAdminTestEmailHandler handles POST /api/platform/admin/channels/email/test.
 // It verifies the email credential can be resolved and the mailbox is accessible.
+// Accepts an optional JSON body with { "secrets": { "key": "value" } } to test
+// with unsaved form values (falls back to stored secrets for any missing keys).
 func PlatformAdminTestEmailHandler(w http.ResponseWriter, r *http.Request) {
 	if RequirePlatformAdmin(w, r) == nil {
 		return
@@ -588,6 +590,20 @@ func PlatformAdminTestEmailHandler(w http.ResponseWriter, r *http.Request) {
 	if secrets == nil {
 		respondError(w, http.StatusServiceUnavailable, "secret store not available")
 		return
+	}
+
+	// Parse optional request body with secret overrides from the form
+	var body struct {
+		Secrets map[string]string `json:"secrets"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body) // ignore error — body may be empty
+
+	// Helper: get secret from form override first, then stored value
+	getSecret := func(key string) string {
+		if v, ok := body.Secrets[key]; ok && v != "" && v != "__CLEAR__" {
+			return v
+		}
+		return secrets.GetSecret(key)
 	}
 
 	backend := getPlatformBackend()
@@ -608,7 +624,7 @@ func PlatformAdminTestEmailHandler(w http.ResponseWriter, r *http.Request) {
 
 	if emailCfg.Provider != "msgraph" {
 		// For IMAP/SMTP, just confirm the password secret is configured
-		password := secrets.GetSecret("channels.email.password")
+		password := getSecret("channels.email.password")
 		if password == "" {
 			respondJSON(w, http.StatusOK, map[string]any{
 				"status":  "error",
@@ -623,11 +639,11 @@ func PlatformAdminTestEmailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Microsoft Graph: read secrets from platform secrets and do token exchange
-	tenantID := secrets.GetSecret("channels.email.tenant_id")
-	clientID := secrets.GetSecret("channels.email.client_id")
-	clientSecret := secrets.GetSecret("channels.email.client_secret") // optional for public clients
-	refreshToken := secrets.GetSecret("channels.email.refresh_token")
+	// Microsoft Graph: read secrets from platform secrets (with form overrides) and do token exchange
+	tenantID := getSecret("channels.email.tenant_id")
+	clientID := getSecret("channels.email.client_id")
+	clientSecret := getSecret("channels.email.client_secret") // optional for public clients
+	refreshToken := getSecret("channels.email.refresh_token")
 
 	if tenantID == "" || clientID == "" || refreshToken == "" {
 		missing := []string{}

--- a/pkg/api/platform_channels_handlers.go
+++ b/pkg/api/platform_channels_handlers.go
@@ -135,8 +135,10 @@ func PlatformAdminListChannelsHandler(w http.ResponseWriter, r *http.Request) {
 			Description: def.description,
 			Config:      map[string]any{},
 		}
+		emailProvider := ""
 		if channels.Email != nil {
 			info.Enabled = channels.Email.Enabled
+			emailProvider = channels.Email.Provider
 			info.Config["provider"] = channels.Email.Provider
 			info.Config["imap_server"] = channels.Email.IMAPServer
 			info.Config["smtp_server"] = channels.Email.SMTPServer
@@ -153,11 +155,14 @@ func PlatformAdminListChannelsHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		allSecretsSet := true
-		for _, s := range def.secrets {
-			configured := secrets.GetSecret(s.key) != ""
-			info.Secrets = append(info.Secrets, channelSecretAt{Key: s.key, Label: s.label, Configured: configured})
-			if !configured {
-				allSecretsSet = false
+		// msgraph uses credential store, not a password secret
+		if emailProvider != "msgraph" {
+			for _, s := range def.secrets {
+				configured := secrets.GetSecret(s.key) != ""
+				info.Secrets = append(info.Secrets, channelSecretAt{Key: s.key, Label: s.label, Configured: configured})
+				if !configured {
+					allSecretsSet = false
+				}
 			}
 		}
 		info.SecretsSet = allSecretsSet

--- a/pkg/api/platform_channels_handlers.go
+++ b/pkg/api/platform_channels_handlers.go
@@ -3,11 +3,13 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/schardosin/astonish/pkg/config"
+	"github.com/schardosin/astonish/pkg/email"
 	"github.com/schardosin/astonish/pkg/store"
 )
 
@@ -70,6 +72,17 @@ var channelDefinitions = map[string]channelDefinition{
 			{"channels.slack.client_secret", "OAuth Client Secret"},
 		},
 	},
+}
+
+// emailMSGraphSecrets defines the secrets needed for Microsoft Graph provider.
+var emailMSGraphSecrets = []struct {
+	key   string
+	label string
+}{
+	{"channels.email.tenant_id", "Tenant ID"},
+	{"channels.email.client_id", "Client ID"},
+	{"channels.email.client_secret", "Client Secret"},
+	{"channels.email.refresh_token", "Refresh Token"},
 }
 
 // PlatformAdminListChannelsHandler handles GET /api/platform/admin/channels.
@@ -155,15 +168,17 @@ func PlatformAdminListChannelsHandler(w http.ResponseWriter, r *http.Request) {
 				info.Config["mark_read"] = true
 			}
 		}
+		// Pick the right secrets list based on provider
+		emailSecrets := def.secrets
+		if emailProvider == "msgraph" {
+			emailSecrets = emailMSGraphSecrets
+		}
 		allSecretsSet := true
-		// msgraph uses credential store, not a password secret
-		if emailProvider != "msgraph" {
-			for _, s := range def.secrets {
-				configured := secrets.GetSecret(s.key) != ""
-				info.Secrets = append(info.Secrets, channelSecretAt{Key: s.key, Label: s.label, Configured: configured})
-				if !configured {
-					allSecretsSet = false
-				}
+		for _, s := range emailSecrets {
+			configured := secrets.GetSecret(s.key) != ""
+			info.Secrets = append(info.Secrets, channelSecretAt{Key: s.key, Label: s.label, Configured: configured})
+			if !configured {
+				allSecretsSet = false
 			}
 		}
 		info.SecretsSet = allSecretsSet
@@ -305,9 +320,23 @@ func PlatformAdminSaveChannelHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Save secrets (only non-empty values; empty means "keep existing")
 	if len(body.Secrets) > 0 {
-		def := channelDefinitions[channelType]
-		allowedKeys := make(map[string]bool, len(def.secrets))
-		for _, s := range def.secrets {
+		// Determine allowed secret keys based on channel type and provider
+		var secretDefs []struct {
+			key   string
+			label string
+		}
+		if channelType == "email" {
+			provider, _ := body.Config["provider"].(string)
+			if provider == "msgraph" {
+				secretDefs = emailMSGraphSecrets
+			} else {
+				secretDefs = channelDefinitions["email"].secrets
+			}
+		} else {
+			secretDefs = channelDefinitions[channelType].secrets
+		}
+		allowedKeys := make(map[string]bool, len(secretDefs))
+		for _, s := range secretDefs {
 			allowedKeys[s.key] = true
 		}
 
@@ -546,6 +575,16 @@ func GetPlatformChannelSettings(ctx context.Context) *store.PlatformChannelSetti
 // PlatformAdminTestEmailHandler handles POST /api/platform/admin/channels/email/test.
 // It verifies the email credential can be resolved and the mailbox is accessible.
 func PlatformAdminTestEmailHandler(w http.ResponseWriter, r *http.Request) {
+	if RequirePlatformAdmin(w, r) == nil {
+		return
+	}
+
+	secrets := getPlatformSecrets()
+	if secrets == nil {
+		respondError(w, http.StatusServiceUnavailable, "secret store not available")
+		return
+	}
+
 	backend := getPlatformBackend()
 	if backend == nil {
 		respondError(w, http.StatusServiceUnavailable, "platform backend not available")
@@ -563,15 +602,13 @@ func PlatformAdminTestEmailHandler(w http.ResponseWriter, r *http.Request) {
 	emailCfg := settings.Channels.Email
 
 	if emailCfg.Provider != "msgraph" {
-		// For IMAP/SMTP, just confirm the secrets are configured
-		secrets := getPlatformSecrets()
-		if secrets == nil {
-			respondError(w, http.StatusServiceUnavailable, "secret store not available")
-			return
-		}
+		// For IMAP/SMTP, just confirm the password secret is configured
 		password := secrets.GetSecret("channels.email.password")
 		if password == "" {
-			respondError(w, http.StatusBadRequest, "email password not configured")
+			respondJSON(w, http.StatusOK, map[string]any{
+				"status":  "error",
+				"message": "Email password not configured",
+			})
 			return
 		}
 		respondJSON(w, http.StatusOK, map[string]any{
@@ -581,40 +618,55 @@ func PlatformAdminTestEmailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Microsoft Graph: resolve the credential and test the connection
-	credName := emailCfg.Credential
-	if credName == "" {
-		respondError(w, http.StatusBadRequest, "credential name not configured for msgraph provider")
-		return
-	}
+	// Microsoft Graph: read secrets from platform secrets and do token exchange
+	tenantID := secrets.GetSecret("channels.email.tenant_id")
+	clientID := secrets.GetSecret("channels.email.client_id")
+	clientSecret := secrets.GetSecret("channels.email.client_secret")
+	refreshToken := secrets.GetSecret("channels.email.refresh_token")
 
-	credStore := getAPICredentialStore()
-	if credStore == nil {
-		respondError(w, http.StatusServiceUnavailable, "credential store not available")
-		return
-	}
-
-	_, headerValue, err := credStore.Resolve(credName)
-	if err != nil {
+	if tenantID == "" || clientID == "" || clientSecret == "" || refreshToken == "" {
+		missing := []string{}
+		if tenantID == "" {
+			missing = append(missing, "Tenant ID")
+		}
+		if clientID == "" {
+			missing = append(missing, "Client ID")
+		}
+		if clientSecret == "" {
+			missing = append(missing, "Client Secret")
+		}
+		if refreshToken == "" {
+			missing = append(missing, "Refresh Token")
+		}
 		respondJSON(w, http.StatusOK, map[string]any{
 			"status":  "error",
-			"message": "Failed to resolve credential: " + err.Error(),
+			"message": fmt.Sprintf("Missing secrets: %s", missing),
 		})
 		return
 	}
 
-	// Test the Graph API connection with /me endpoint
-	token := headerValue
-	if len(token) > 7 && token[:7] == "Bearer " {
-		token = token[7:]
+	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
+	tokenResp, err := email.ExchangeMSGraphToken(r.Context(), tokenURL, clientID, clientSecret, refreshToken)
+	if err != nil {
+		respondJSON(w, http.StatusOK, map[string]any{
+			"status":  "error",
+			"message": "Token exchange failed: " + err.Error(),
+		})
+		return
 	}
 
+	// Persist rotated refresh token if Microsoft returned a new one
+	if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != refreshToken {
+		_ = secrets.SetSecret("channels.email.refresh_token", tokenResp.RefreshToken)
+	}
+
+	// Test the Graph API connection with /me endpoint
 	req, err := http.NewRequestWithContext(r.Context(), "GET", "https://graph.microsoft.com/v1.0/me", nil)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to build request")
 		return
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
 
 	client := &http.Client{Timeout: 15 * time.Second}
 	resp, err := client.Do(req)

--- a/pkg/api/platform_channels_handlers.go
+++ b/pkg/api/platform_channels_handlers.go
@@ -134,6 +134,7 @@ func PlatformAdminListChannelsHandler(w http.ResponseWriter, r *http.Request) {
 			Type:        "email",
 			Description: def.description,
 			Config:      map[string]any{},
+			Secrets:     []channelSecretAt{},
 		}
 		emailProvider := ""
 		if channels.Email != nil {

--- a/pkg/api/platform_channels_handlers.go
+++ b/pkg/api/platform_channels_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/schardosin/astonish/pkg/config"
@@ -141,6 +142,7 @@ func PlatformAdminListChannelsHandler(w http.ResponseWriter, r *http.Request) {
 			info.Config["smtp_server"] = channels.Email.SMTPServer
 			info.Config["address"] = channels.Email.Address
 			info.Config["username"] = channels.Email.Username
+			info.Config["credential"] = channels.Email.Credential
 			info.Config["poll_interval"] = channels.Email.PollInterval
 			info.Config["folder"] = channels.Email.Folder
 			info.Config["max_body_chars"] = channels.Email.MaxBodyChars
@@ -263,6 +265,9 @@ func PlatformAdminSaveChannelHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		if v, ok := body.Config["username"].(string); ok {
 			cfg.Username = v
+		}
+		if v, ok := body.Config["credential"].(string); ok {
+			cfg.Credential = v
 		}
 		if v, ok := body.Config["poll_interval"]; ok {
 			cfg.PollInterval = toInt(v)
@@ -530,4 +535,111 @@ func GetPlatformChannelSettings(ctx context.Context) *store.PlatformChannelSetti
 		return nil
 	}
 	return settings.Channels
+}
+
+// PlatformAdminTestEmailHandler handles POST /api/platform/admin/channels/email/test.
+// It verifies the email credential can be resolved and the mailbox is accessible.
+func PlatformAdminTestEmailHandler(w http.ResponseWriter, r *http.Request) {
+	backend := getPlatformBackend()
+	if backend == nil {
+		respondError(w, http.StatusServiceUnavailable, "platform backend not available")
+		return
+	}
+
+	// Load the email config
+	settingsStore := backend.PlatformSettings()
+	settings, err := settingsStore.Get(r.Context())
+	if err != nil || settings == nil || settings.Channels == nil || settings.Channels.Email == nil {
+		respondError(w, http.StatusBadRequest, "no email channel configured")
+		return
+	}
+
+	emailCfg := settings.Channels.Email
+
+	if emailCfg.Provider != "msgraph" {
+		// For IMAP/SMTP, just confirm the secrets are configured
+		secrets := getPlatformSecrets()
+		if secrets == nil {
+			respondError(w, http.StatusServiceUnavailable, "secret store not available")
+			return
+		}
+		password := secrets.GetSecret("channels.email.password")
+		if password == "" {
+			respondError(w, http.StatusBadRequest, "email password not configured")
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]any{
+			"status":  "ok",
+			"message": "IMAP/SMTP credentials are configured (connection not tested)",
+		})
+		return
+	}
+
+	// Microsoft Graph: resolve the credential and test the connection
+	credName := emailCfg.Credential
+	if credName == "" {
+		respondError(w, http.StatusBadRequest, "credential name not configured for msgraph provider")
+		return
+	}
+
+	credStore := getAPICredentialStore()
+	if credStore == nil {
+		respondError(w, http.StatusServiceUnavailable, "credential store not available")
+		return
+	}
+
+	_, headerValue, err := credStore.Resolve(credName)
+	if err != nil {
+		respondJSON(w, http.StatusOK, map[string]any{
+			"status":  "error",
+			"message": "Failed to resolve credential: " + err.Error(),
+		})
+		return
+	}
+
+	// Test the Graph API connection with /me endpoint
+	token := headerValue
+	if len(token) > 7 && token[:7] == "Bearer " {
+		token = token[7:]
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), "GET", "https://graph.microsoft.com/v1.0/me", nil)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to build request")
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		respondJSON(w, http.StatusOK, map[string]any{
+			"status":  "error",
+			"message": "Connection failed: " + err.Error(),
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respondJSON(w, http.StatusOK, map[string]any{
+			"status":  "error",
+			"message": "Graph API returned " + resp.Status,
+		})
+		return
+	}
+
+	// Decode user info for confirmation
+	var meResp struct {
+		Mail        string `json:"mail"`
+		DisplayName string `json:"displayName"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&meResp)
+
+	respondJSON(w, http.StatusOK, map[string]any{
+		"status":      "ok",
+		"message":     "Connected successfully",
+		"email":       meResp.Mail,
+		"displayName": meResp.DisplayName,
+	})
 }

--- a/pkg/api/platform_channels_handlers.go
+++ b/pkg/api/platform_channels_handlers.go
@@ -621,19 +621,16 @@ func PlatformAdminTestEmailHandler(w http.ResponseWriter, r *http.Request) {
 	// Microsoft Graph: read secrets from platform secrets and do token exchange
 	tenantID := secrets.GetSecret("channels.email.tenant_id")
 	clientID := secrets.GetSecret("channels.email.client_id")
-	clientSecret := secrets.GetSecret("channels.email.client_secret")
+	clientSecret := secrets.GetSecret("channels.email.client_secret") // optional for public clients
 	refreshToken := secrets.GetSecret("channels.email.refresh_token")
 
-	if tenantID == "" || clientID == "" || clientSecret == "" || refreshToken == "" {
+	if tenantID == "" || clientID == "" || refreshToken == "" {
 		missing := []string{}
 		if tenantID == "" {
 			missing = append(missing, "Tenant ID")
 		}
 		if clientID == "" {
 			missing = append(missing, "Client ID")
-		}
-		if clientSecret == "" {
-			missing = append(missing, "Client Secret")
 		}
 		if refreshToken == "" {
 			missing = append(missing, "Refresh Token")

--- a/pkg/api/platform_channels_handlers.go
+++ b/pkg/api/platform_channels_handlers.go
@@ -31,58 +31,50 @@ type channelSecretAt struct {
 	Configured bool  `json:"configured"`
 }
 
+// channelSecretDef defines a single secret field for a channel.
+type channelSecretDef struct {
+	key      string
+	label    string
+	optional bool
+}
+
 // channelDefinition defines the metadata for each channel type.
 type channelDefinition struct {
 	description string
-	secrets     []struct {
-		key   string
-		label string
-	}
+	secrets     []channelSecretDef
 }
 
 var channelDefinitions = map[string]channelDefinition{
 	"telegram": {
 		description: "Telegram Bot (via BotFather)",
-		secrets: []struct {
-			key   string
-			label string
-		}{
-			{"channels.telegram.bot_token", "Bot Token"},
+		secrets: []channelSecretDef{
+			{key: "channels.telegram.bot_token", label: "Bot Token"},
 		},
 	},
 	"email": {
 		description: "Email (IMAP/SMTP)",
-		secrets: []struct {
-			key   string
-			label string
-		}{
-			{"channels.email.password", "IMAP/SMTP Password"},
+		secrets: []channelSecretDef{
+			{key: "channels.email.password", label: "IMAP/SMTP Password"},
 		},
 	},
 	"slack": {
 		description: "Slack App",
-		secrets: []struct {
-			key   string
-			label string
-		}{
-			{"channels.slack.bot_token", "Bot Token (xoxb-...)"},
-			{"channels.slack.app_token", "App-Level Token (xapp-...)"},
-			{"channels.slack.signing_secret", "Signing Secret"},
-			{"channels.slack.client_id", "OAuth Client ID"},
-			{"channels.slack.client_secret", "OAuth Client Secret"},
+		secrets: []channelSecretDef{
+			{key: "channels.slack.bot_token", label: "Bot Token (xoxb-...)"},
+			{key: "channels.slack.app_token", label: "App-Level Token (xapp-...)"},
+			{key: "channels.slack.signing_secret", label: "Signing Secret"},
+			{key: "channels.slack.client_id", label: "OAuth Client ID"},
+			{key: "channels.slack.client_secret", label: "OAuth Client Secret"},
 		},
 	},
 }
 
 // emailMSGraphSecrets defines the secrets needed for Microsoft Graph provider.
-var emailMSGraphSecrets = []struct {
-	key   string
-	label string
-}{
-	{"channels.email.tenant_id", "Tenant ID"},
-	{"channels.email.client_id", "Client ID"},
-	{"channels.email.client_secret", "Client Secret"},
-	{"channels.email.refresh_token", "Refresh Token"},
+var emailMSGraphSecrets = []channelSecretDef{
+	{key: "channels.email.tenant_id", label: "Tenant ID"},
+	{key: "channels.email.client_id", label: "Client ID"},
+	{key: "channels.email.client_secret", label: "Client Secret (optional)", optional: true},
+	{key: "channels.email.refresh_token", label: "Refresh Token"},
 }
 
 // PlatformAdminListChannelsHandler handles GET /api/platform/admin/channels.
@@ -177,7 +169,7 @@ func PlatformAdminListChannelsHandler(w http.ResponseWriter, r *http.Request) {
 		for _, s := range emailSecrets {
 			configured := secrets.GetSecret(s.key) != ""
 			info.Secrets = append(info.Secrets, channelSecretAt{Key: s.key, Label: s.label, Configured: configured})
-			if !configured {
+			if !configured && !s.optional {
 				allSecretsSet = false
 			}
 		}
@@ -321,10 +313,7 @@ func PlatformAdminSaveChannelHandler(w http.ResponseWriter, r *http.Request) {
 	// Save secrets (only non-empty values; empty means "keep existing")
 	if len(body.Secrets) > 0 {
 		// Determine allowed secret keys based on channel type and provider
-		var secretDefs []struct {
-			key   string
-			label string
-		}
+		var secretDefs []channelSecretDef
 		if channelType == "email" {
 			provider, _ := body.Config["provider"].(string)
 			if provider == "msgraph" {

--- a/pkg/api/platform_channels_handlers.go
+++ b/pkg/api/platform_channels_handlers.go
@@ -353,6 +353,11 @@ func PlatformAdminSaveChannelHandler(w http.ResponseWriter, r *http.Request) {
 			if value == "" {
 				continue // empty = keep existing
 			}
+			if value == "__CLEAR__" {
+				// Explicitly remove the secret
+				_ = secretStore.RemoveSecret(key)
+				continue
+			}
 			if err := secretStore.SetSecret(key, value); err != nil {
 				respondError(w, http.StatusInternalServerError, "failed to save secret: "+err.Error())
 				return

--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -22,15 +22,17 @@ import (
 
 // Config holds configuration for the Email channel adapter.
 type Config struct {
-	// Provider selects the implementation: "imap" or "gmail". Default: "imap".
+	// Provider selects the implementation: "imap", "gmail", or "msgraph". Default: "imap".
 	Provider string
-	// IMAP/SMTP server addresses
+	// IMAP/SMTP server addresses (not used for msgraph)
 	IMAPServer string
 	SMTPServer string
 	// Agent's email address and login credentials
 	Address  string
 	Username string
 	Password string
+	// TokenFunc provides a valid OAuth2 access token (used by msgraph provider).
+	TokenFunc emailpkg.TokenFunc
 	// Behavior
 	PollInterval time.Duration // How often to check for new emails. Default: 30s
 	AllowFrom    []string      // Allowed sender addresses (empty = block all, ["*"] = allow all)
@@ -114,7 +116,7 @@ func (e *EmailChannel) ID() string { return "email" }
 // Name returns a human-readable name.
 func (e *EmailChannel) Name() string { return "Email" }
 
-// Start connects to the IMAP server and begins polling for new emails.
+// Start connects to the email server and begins polling for new emails.
 // It calls handler for each normalized inbound email. Blocks until ctx
 // is cancelled or Stop is called.
 func (e *EmailChannel) Start(ctx context.Context, handler channels.MessageHandler) error {
@@ -126,6 +128,7 @@ func (e *EmailChannel) Start(ctx context.Context, handler channels.MessageHandle
 		Address:      e.config.Address,
 		Username:     e.config.Username,
 		Password:     e.config.Password,
+		TokenFunc:    e.config.TokenFunc,
 		Folder:       e.config.Folder,
 		MarkRead:     e.config.MarkRead,
 		MaxBodyChars: e.config.MaxBodyChars,
@@ -152,7 +155,11 @@ func (e *EmailChannel) Start(ctx context.Context, handler channels.MessageHandle
 	}
 	e.mu.Unlock()
 
-	e.logger.Printf("[email] Connected as %s (IMAP: %s)", e.config.Address, e.config.IMAPServer)
+	if e.config.Provider == "msgraph" {
+		e.logger.Printf("[email] Connected as %s (Microsoft Graph)", e.config.Address)
+	} else {
+		e.logger.Printf("[email] Connected as %s (IMAP: %s)", e.config.Address, e.config.IMAPServer)
+	}
 
 	// Create cancellable context for polling
 	pollCtx, cancel := context.WithCancel(ctx)

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -1220,19 +1220,27 @@ func (c *TelegramConfig) IsTelegramEnabled() bool {
 type EmailConfig struct {
 	// Enabled controls whether the Email adapter is active. Default: false (nil means false).
 	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	// Provider selects the implementation: "imap" or "gmail". Default: "imap".
+	// Provider selects the implementation: "imap", "gmail", or "msgraph". Default: "imap".
 	Provider string `yaml:"provider,omitempty" json:"provider,omitempty"`
 	// IMAPServer is the IMAP server address (e.g., "imap.gmail.com:993").
+	// Not used when Provider is "msgraph".
 	IMAPServer string `yaml:"imap_server,omitempty" json:"imap_server,omitempty"`
 	// SMTPServer is the SMTP server address (e.g., "smtp.gmail.com:587").
+	// Not used when Provider is "msgraph".
 	SMTPServer string `yaml:"smtp_server,omitempty" json:"smtp_server,omitempty"`
 	// Address is the agent's email address.
 	Address string `yaml:"address,omitempty" json:"address,omitempty"`
 	// Username is the IMAP/SMTP login username. Often same as Address.
+	// Not used when Provider is "msgraph".
 	Username string `yaml:"username,omitempty" json:"username,omitempty"`
 	// Password is the IMAP/SMTP password or app password.
 	// After credential migration, this will be empty (stored in encrypted store).
+	// Not used when Provider is "msgraph".
 	Password string `yaml:"password,omitempty" json:"password,omitempty"`
+	// Credential is the name of the credential in the encrypted credential store.
+	// Required when Provider is "msgraph" — must reference an oauth_authorization_code
+	// credential holding the Microsoft Graph OAuth2 tokens.
+	Credential string `yaml:"credential,omitempty" json:"credential,omitempty"`
 	// PollInterval is seconds between inbox checks. Default: 30.
 	PollInterval int `yaml:"poll_interval,omitempty" json:"poll_interval,omitempty"`
 	// AllowFrom is a list of email addresses allowed to trigger the agent.

--- a/pkg/daemon/platform_channel_config.go
+++ b/pkg/daemon/platform_channel_config.go
@@ -49,14 +49,20 @@ func loadChannelsConfigFromDB(backend platformDB, logger *Logger) config.Channel
 		out.Email.SMTPServer = ch.Email.SMTPServer
 		out.Email.Address = ch.Email.Address
 		out.Email.Username = ch.Email.Username
+		out.Email.Credential = ch.Email.Credential
 		out.Email.PollInterval = ch.Email.PollInterval
 		out.Email.Folder = ch.Email.Folder
 		out.Email.MarkRead = ch.Email.MarkRead
 		out.Email.MaxBodyChars = ch.Email.MaxBodyChars
 
 		if enabled && logger != nil {
-			logger.Printf("[channels] DB config: Email enabled address=%s imap=%s smtp=%s",
-				out.Email.Address, out.Email.IMAPServer, out.Email.SMTPServer)
+			if ch.Email.Provider == "msgraph" {
+				logger.Printf("[channels] DB config: Email enabled (msgraph) address=%s credential=%s",
+					out.Email.Address, out.Email.Credential)
+			} else {
+				logger.Printf("[channels] DB config: Email enabled address=%s imap=%s smtp=%s",
+					out.Email.Address, out.Email.IMAPServer, out.Email.SMTPServer)
+			}
 		}
 	}
 

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -546,30 +545,62 @@ func Run(cfg RunConfig) error {
 
 		emailCh := loadChannelsConfigFromDB(backend, logger).Email
 
-		// Microsoft Graph provider uses OAuth credential store instead of password
+		// Microsoft Graph provider uses platform secrets for OAuth tokens
 		if emailCh.Provider == "msgraph" {
-			credName := emailCh.Credential
-			if credName == "" {
-				credName = resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.credential")
-			}
-			if credName == "" || emailCh.Address == "" {
+			if emailCh.Address == "" {
 				return
 			}
-			if factoryResult.CredentialStore == nil {
-				logger.Printf("Warning: msgraph email provider requires credential store but none is available")
+			// Resolve the 4 OAuth secrets from platform secrets
+			tenantID := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.tenant_id")
+			clientID := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.client_id")
+			clientSecret := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.client_secret")
+			refreshToken := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.refresh_token")
+			if tenantID == "" || clientID == "" || clientSecret == "" || refreshToken == "" {
+				logger.Printf("Warning: msgraph email provider missing required secrets (tenant_id, client_id, client_secret, refresh_token)")
 				return
 			}
-			// Create a TokenFunc that resolves the credential on each call
-			credStore := factoryResult.CredentialStore
+			tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
+
+			// Token cache: exchange once and reuse until near expiry
+			var (
+				cachedToken string
+				tokenExpiry time.Time
+				tokenMu     sync.Mutex
+			)
+
 			tokenFunc := func() (string, error) {
-				_, headerValue, err := credStore.Resolve(credName)
-				if err != nil {
-					return "", fmt.Errorf("resolve credential %q: %w", credName, err)
+				tokenMu.Lock()
+				defer tokenMu.Unlock()
+
+				// Return cached token if still valid (with 5-minute buffer)
+				if cachedToken != "" && time.Now().Before(tokenExpiry.Add(-5*time.Minute)) {
+					return cachedToken, nil
 				}
-				// headerValue is "Bearer <token>" — extract just the token
-				token := strings.TrimPrefix(headerValue, "Bearer ")
-				return token, nil
+
+				// Get current refresh token (may have been rotated by the API test handler)
+				currentRefresh := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.refresh_token")
+				if currentRefresh == "" {
+					currentRefresh = refreshToken
+				}
+
+				tokenResp, err := emailpkg.ExchangeMSGraphToken(context.Background(), tokenURL, clientID, clientSecret, currentRefresh)
+				if err != nil {
+					return "", fmt.Errorf("msgraph token exchange: %w", err)
+				}
+
+				cachedToken = tokenResp.AccessToken
+				tokenExpiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+				// Persist rotated refresh token via platform secrets API
+				if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != currentRefresh {
+					if ps := api.GetPlatformSecrets(); ps != nil {
+						_ = ps.SetSecret("channels.email.refresh_token", tokenResp.RefreshToken)
+					}
+				}
+
+				return cachedToken, nil
 			}
+
 			setupEmailTools(&emailToolConfig{
 				Provider:     "msgraph",
 				Address:      emailCh.Address,

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -553,10 +553,10 @@ func Run(cfg RunConfig) error {
 			// Resolve the 4 OAuth secrets from platform secrets
 			tenantID := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.tenant_id")
 			clientID := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.client_id")
-			clientSecret := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.client_secret")
+			clientSecret := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.client_secret") // optional for public clients
 			refreshToken := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.refresh_token")
-			if tenantID == "" || clientID == "" || clientSecret == "" || refreshToken == "" {
-				logger.Printf("Warning: msgraph email provider missing required secrets (tenant_id, client_id, client_secret, refresh_token)")
+			if tenantID == "" || clientID == "" || refreshToken == "" {
+				logger.Printf("Warning: msgraph email provider missing required secrets (tenant_id, client_id, refresh_token)")
 				return
 			}
 			tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -441,39 +441,98 @@ func Run(cfg RunConfig) error {
 		// Register Email channel (inbound polling) only if explicitly enabled (DB is source of truth)
 		var emailConfigError string
 		if chCfg.Email.IsEmailEnabled() {
-			emailPassword := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.password")
-			if emailPassword == "" {
-				emailConfigError = "password not configured"
-				logger.Printf("Warning: Email channel enabled but no password found")
-			} else if chCfg.Email.IMAPServer == "" || chCfg.Email.SMTPServer == "" {
-				emailConfigError = "IMAP/SMTP servers not configured"
-				logger.Printf("Warning: Email channel enabled but IMAP/SMTP servers not configured")
-			} else {
-				pollInterval := time.Duration(chCfg.Email.GetPollInterval()) * time.Second
-				emailAllowFrom := chCfg.Email.AllowFrom
-				if backend != nil {
-					emailAllowFrom = nil
+			pollInterval := time.Duration(chCfg.Email.GetPollInterval()) * time.Second
+			emailAllowFrom := chCfg.Email.AllowFrom
+			if backend != nil {
+				emailAllowFrom = nil
+			}
+
+			if chCfg.Email.Provider == "msgraph" {
+				// Microsoft Graph provider — uses OAuth token exchange
+				tenantID := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.tenant_id")
+				clientID := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.client_id")
+				clientSecret := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.client_secret")
+				refreshToken := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.refresh_token")
+				if tenantID == "" || clientID == "" || refreshToken == "" {
+					emailConfigError = "Microsoft Graph secrets not configured (tenant_id, client_id, refresh_token)"
+					logger.Printf("Warning: Email channel enabled but msgraph secrets missing")
+				} else if chCfg.Email.Address == "" {
+					emailConfigError = "email address not configured"
+					logger.Printf("Warning: Email channel enabled but no address configured")
+				} else {
+					tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID)
+					var (
+						cachedToken string
+						tokenExpiry time.Time
+						tokenMu     sync.Mutex
+					)
+					tokenFunc := func() (string, error) {
+						tokenMu.Lock()
+						defer tokenMu.Unlock()
+						if cachedToken != "" && time.Now().Before(tokenExpiry.Add(-5*time.Minute)) {
+							return cachedToken, nil
+						}
+						currentRefresh := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.refresh_token")
+						if currentRefresh == "" {
+							currentRefresh = refreshToken
+						}
+						tokenResp, err := emailpkg.ExchangeMSGraphToken(context.Background(), tokenURL, clientID, clientSecret, currentRefresh)
+						if err != nil {
+							return "", fmt.Errorf("msgraph token exchange: %w", err)
+						}
+						cachedToken = tokenResp.AccessToken
+						tokenExpiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+						if tokenResp.RefreshToken != "" && tokenResp.RefreshToken != currentRefresh {
+							if ps := api.GetPlatformSecrets(); ps != nil {
+								_ = ps.SetSecret("channels.email.refresh_token", tokenResp.RefreshToken)
+							}
+						}
+						return cachedToken, nil
+					}
+
+					em := emailchan.New(&emailchan.Config{
+						Provider:     "msgraph",
+						Address:      chCfg.Email.Address,
+						TokenFunc:    tokenFunc,
+						PollInterval: pollInterval,
+						AllowFrom:    emailAllowFrom,
+						Folder:       chCfg.Email.Folder,
+						MarkRead:     chCfg.Email.IsMarkRead(),
+						MaxBodyChars: chCfg.Email.MaxBodyChars,
+						Commands:     mgr.Commands(),
+					}, log.Default())
+					em.SetThreadIndex(backend.NewThreadIndex())
+					mgr.Register(em)
+					logger.Printf("Email channel registered via Microsoft Graph (%s)", chCfg.Email.Address)
 				}
-				em := emailchan.New(&emailchan.Config{
-					Provider:     chCfg.Email.Provider,
-					IMAPServer:   chCfg.Email.IMAPServer,
-					SMTPServer:   chCfg.Email.SMTPServer,
-					Address:      chCfg.Email.Address,
-					Username:     chCfg.Email.Username,
-					Password:     emailPassword,
-					PollInterval: pollInterval,
-					AllowFrom:    emailAllowFrom,
-					Folder:       chCfg.Email.Folder,
-					MarkRead:     chCfg.Email.IsMarkRead(),
-					MaxBodyChars: chCfg.Email.MaxBodyChars,
-					Commands:     mgr.Commands(),
-				}, log.Default())
-				// Inject thread index for per-thread email sessions.
-				// Each email thread gets its own session; replies chain back
-				// to the same session via In-Reply-To / References headers.
-				em.SetThreadIndex(backend.NewThreadIndex())
-				mgr.Register(em)
-				logger.Printf("Email channel registered (%s)", chCfg.Email.Address)
+			} else {
+				// IMAP/SMTP provider
+				emailPassword := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.password")
+				if emailPassword == "" {
+					emailConfigError = "password not configured"
+					logger.Printf("Warning: Email channel enabled but no password found")
+				} else if chCfg.Email.IMAPServer == "" || chCfg.Email.SMTPServer == "" {
+					emailConfigError = "IMAP/SMTP servers not configured"
+					logger.Printf("Warning: Email channel enabled but IMAP/SMTP servers not configured")
+				} else {
+					em := emailchan.New(&emailchan.Config{
+						Provider:     chCfg.Email.Provider,
+						IMAPServer:   chCfg.Email.IMAPServer,
+						SMTPServer:   chCfg.Email.SMTPServer,
+						Address:      chCfg.Email.Address,
+						Username:     chCfg.Email.Username,
+						Password:     emailPassword,
+						PollInterval: pollInterval,
+						AllowFrom:    emailAllowFrom,
+						Folder:       chCfg.Email.Folder,
+						MarkRead:     chCfg.Email.IsMarkRead(),
+						MaxBodyChars: chCfg.Email.MaxBodyChars,
+						Commands:     mgr.Commands(),
+					}, log.Default())
+					em.SetThreadIndex(backend.NewThreadIndex())
+					mgr.Register(em)
+					logger.Printf("Email channel registered (%s)", chCfg.Email.Address)
+				}
 			}
 		}
 

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -544,6 +545,43 @@ func Run(cfg RunConfig) error {
 		}
 
 		emailCh := loadChannelsConfigFromDB(backend, logger).Email
+
+		// Microsoft Graph provider uses OAuth credential store instead of password
+		if emailCh.Provider == "msgraph" {
+			credName := emailCh.Credential
+			if credName == "" {
+				credName = resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.credential")
+			}
+			if credName == "" || emailCh.Address == "" {
+				return
+			}
+			if factoryResult.CredentialStore == nil {
+				logger.Printf("Warning: msgraph email provider requires credential store but none is available")
+				return
+			}
+			// Create a TokenFunc that resolves the credential on each call
+			credStore := factoryResult.CredentialStore
+			tokenFunc := func() (string, error) {
+				_, headerValue, err := credStore.Resolve(credName)
+				if err != nil {
+					return "", fmt.Errorf("resolve credential %q: %w", credName, err)
+				}
+				// headerValue is "Bearer <token>" — extract just the token
+				token := strings.TrimPrefix(headerValue, "Bearer ")
+				return token, nil
+			}
+			setupEmailTools(&emailToolConfig{
+				Provider:     "msgraph",
+				Address:      emailCh.Address,
+				Folder:       emailCh.Folder,
+				MaxBodyChars: emailCh.MaxBodyChars,
+				TokenFunc:    tokenFunc,
+			})
+			logger.Printf("Email tools initialized via Microsoft Graph (%s)", emailCh.Address)
+			return
+		}
+
+		// IMAP/SMTP provider — requires password
 		emailPassword := resolveDaemonSecret(backend, factoryResult.CredentialStore, "channels.email.password")
 		if emailPassword == "" || emailCh.IMAPServer == "" ||
 			emailCh.SMTPServer == "" || emailCh.Address == "" {
@@ -1512,6 +1550,8 @@ type emailToolConfig struct {
 	Password     string
 	Folder       string
 	MaxBodyChars int
+	// TokenFunc provides a valid OAuth2 access token (for msgraph provider).
+	TokenFunc emailpkg.TokenFunc
 }
 
 // setupEmailTools creates an email client and registers it for the email tools.
@@ -1525,6 +1565,7 @@ func setupEmailTools(cfg *emailToolConfig) {
 		Password:     cfg.Password,
 		Folder:       cfg.Folder,
 		MaxBodyChars: cfg.MaxBodyChars,
+		TokenFunc:    cfg.TokenFunc,
 	}
 	client, err := emailpkg.NewClient(emailCfg)
 	if err != nil {

--- a/pkg/email/client.go
+++ b/pkg/email/client.go
@@ -5,6 +5,7 @@ package email
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -131,15 +132,23 @@ type Client interface {
 
 // Config holds configuration for creating an email client.
 type Config struct {
-	// Provider selects the implementation: "imap" or "gmail"
+	// Provider selects the implementation: "imap", "gmail", or "msgraph"
 	Provider string
 
-	// IMAP/SMTP settings
+	// IMAP/SMTP settings (used by "imap" and "gmail" providers)
 	IMAPServer string
 	SMTPServer string
 	Address    string
 	Username   string
 	Password   string
+
+	// Microsoft Graph settings (used by "msgraph" provider)
+	// Credential is the name of the oauth_authorization_code credential
+	// in the encrypted credential store that holds the OAuth2 tokens.
+	Credential string
+	// TokenFunc provides a valid OAuth2 access token on each call.
+	// Set by the daemon when wiring up the msgraph provider.
+	TokenFunc TokenFunc
 
 	// Behavior
 	PollInterval time.Duration
@@ -165,7 +174,12 @@ func NewClient(cfg *Config) (Client, error) {
 		cfg = DefaultConfig()
 	}
 	switch cfg.Provider {
-	case "imap", "":
+	case "msgraph":
+		if cfg.TokenFunc == nil {
+			return nil, fmt.Errorf("msgraph provider requires TokenFunc to be set (configure a credential)")
+		}
+		return NewMSGraphClient(cfg, cfg.TokenFunc), nil
+	case "imap", "gmail", "":
 		return NewIMAPSMTPClient(cfg), nil
 	default:
 		return NewIMAPSMTPClient(cfg), nil

--- a/pkg/email/client.go
+++ b/pkg/email/client.go
@@ -143,8 +143,8 @@ type Config struct {
 	Password   string
 
 	// Microsoft Graph settings (used by "msgraph" provider)
-	// Credential is the name of the oauth_authorization_code credential
-	// in the encrypted credential store that holds the OAuth2 tokens.
+	// Credential is unused in platform mode (secrets stored as platform secrets).
+	// Retained for backward compatibility with personal-mode configs.
 	Credential string
 	// TokenFunc provides a valid OAuth2 access token on each call.
 	// Set by the daemon when wiring up the msgraph provider.

--- a/pkg/email/msgraph.go
+++ b/pkg/email/msgraph.go
@@ -750,7 +750,7 @@ func ExchangeMSGraphToken(ctx context.Context, tokenURL, clientID, clientSecret,
 		"client_secret": {clientSecret},
 		"refresh_token": {refreshToken},
 		"grant_type":    {"refresh_token"},
-		"scope":         {"https://graph.microsoft.com/.default offline_access"},
+		"scope":         {"https://graph.microsoft.com/.default"},
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(data.Encode()))

--- a/pkg/email/msgraph.go
+++ b/pkg/email/msgraph.go
@@ -1,0 +1,732 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// graphBaseURL is the Microsoft Graph API v1.0 base URL.
+	graphBaseURL = "https://graph.microsoft.com/v1.0"
+
+	// graphTimeout is the HTTP timeout for Graph API requests.
+	graphTimeout = 30 * time.Second
+
+	// graphMaxPageSize is the maximum number of messages per request.
+	graphMaxPageSize = 50
+)
+
+// TokenFunc is a function that returns a valid OAuth2 access token.
+// The implementation should handle token refresh transparently.
+type TokenFunc func() (string, error)
+
+// MSGraphClient implements the Client interface using Microsoft Graph API
+// with delegated OAuth2 permissions for a single user mailbox.
+type MSGraphClient struct {
+	cfg       *Config
+	tokenFunc TokenFunc
+	client    *http.Client
+	mu        sync.Mutex
+	connected bool
+}
+
+// NewMSGraphClient creates a new Microsoft Graph email client.
+// The tokenFunc is called on each API request to obtain a valid access token.
+func NewMSGraphClient(cfg *Config, tokenFunc TokenFunc) *MSGraphClient {
+	return &MSGraphClient{
+		cfg:       cfg,
+		tokenFunc: tokenFunc,
+		client:    &http.Client{Timeout: graphTimeout},
+	}
+}
+
+// Connect verifies the token can be obtained and the mailbox is accessible.
+func (c *MSGraphClient) Connect(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Verify we can get a token and access the mailbox
+	token, err := c.tokenFunc()
+	if err != nil {
+		return fmt.Errorf("msgraph: failed to obtain access token: %w", err)
+	}
+
+	// Test with a simple /me request
+	req, err := http.NewRequestWithContext(ctx, "GET", graphBaseURL+"/me", nil)
+	if err != nil {
+		return fmt.Errorf("msgraph: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("msgraph: connection test failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("msgraph: connection test returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	c.connected = true
+	return nil
+}
+
+// Close is a no-op for HTTP-based Graph API client.
+func (c *MSGraphClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.connected = false
+	return nil
+}
+
+// IsConnected returns whether Connect() succeeded.
+func (c *MSGraphClient) IsConnected() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.connected
+}
+
+// Address returns the configured email address.
+func (c *MSGraphClient) Address() string {
+	return c.cfg.Address
+}
+
+// ListMessages returns email summaries from the mailbox.
+func (c *MSGraphClient) ListMessages(ctx context.Context, opts ListOpts) ([]MessageSummary, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > graphMaxPageSize {
+		limit = graphMaxPageSize
+	}
+
+	// Build OData filter
+	var filters []string
+	folder := opts.Folder
+	if folder == "" {
+		folder = c.cfg.Folder
+	}
+	if folder == "" {
+		folder = "Inbox"
+	}
+
+	if opts.Unread {
+		filters = append(filters, "isRead eq false")
+	}
+	if opts.From != "" {
+		filters = append(filters, fmt.Sprintf("contains(from/emailAddress/address,'%s')", escapeOData(opts.From)))
+	}
+	if opts.Subject != "" {
+		filters = append(filters, fmt.Sprintf("contains(subject,'%s')", escapeOData(opts.Subject)))
+	}
+	if !opts.Since.IsZero() {
+		filters = append(filters, fmt.Sprintf("receivedDateTime ge %s", opts.Since.UTC().Format(time.RFC3339)))
+	}
+
+	// Build URL
+	endpoint := fmt.Sprintf("%s/me/mailFolders/%s/messages", graphBaseURL, url.PathEscape(folder))
+	params := url.Values{}
+	params.Set("$top", fmt.Sprintf("%d", limit))
+	params.Set("$orderby", "receivedDateTime desc")
+	params.Set("$select", "id,from,toRecipients,subject,receivedDateTime,isRead,hasAttachments,internetMessageId,internetMessageHeaders")
+	if len(filters) > 0 {
+		params.Set("$filter", strings.Join(filters, " and "))
+	}
+
+	var result graphMessageList
+	if err := c.graphGet(ctx, endpoint+"?"+params.Encode(), &result); err != nil {
+		return nil, fmt.Errorf("msgraph: list messages: %w", err)
+	}
+
+	summaries := make([]MessageSummary, 0, len(result.Value))
+	for _, m := range result.Value {
+		summaries = append(summaries, m.toSummary())
+	}
+	return summaries, nil
+}
+
+// ReadMessage returns the full content of a specific email.
+func (c *MSGraphClient) ReadMessage(ctx context.Context, id string) (*Message, error) {
+	endpoint := fmt.Sprintf("%s/me/messages/%s", graphBaseURL, url.PathEscape(id))
+	params := url.Values{}
+	params.Set("$expand", "attachments($select=id,name,size,contentType,isInline)")
+
+	var gMsg graphMessage
+	if err := c.graphGet(ctx, endpoint+"?"+params.Encode(), &gMsg); err != nil {
+		return nil, fmt.Errorf("msgraph: read message: %w", err)
+	}
+
+	msg := gMsg.toMessage(c.cfg.MaxBodyChars)
+	return msg, nil
+}
+
+// SearchMessages searches emails with the given criteria.
+func (c *MSGraphClient) SearchMessages(ctx context.Context, query SearchQuery) ([]MessageSummary, error) {
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > graphMaxPageSize {
+		limit = graphMaxPageSize
+	}
+
+	folder := query.Folder
+	if folder == "" {
+		folder = c.cfg.Folder
+	}
+	if folder == "" {
+		folder = "Inbox"
+	}
+
+	var filters []string
+	if query.From != "" {
+		filters = append(filters, fmt.Sprintf("contains(from/emailAddress/address,'%s')", escapeOData(query.From)))
+	}
+	if query.To != "" {
+		filters = append(filters, fmt.Sprintf("contains(toRecipients/emailAddress/address,'%s')", escapeOData(query.To)))
+	}
+	if query.Subject != "" {
+		filters = append(filters, fmt.Sprintf("contains(subject,'%s')", escapeOData(query.Subject)))
+	}
+	if !query.Since.IsZero() {
+		filters = append(filters, fmt.Sprintf("receivedDateTime ge %s", query.Since.UTC().Format(time.RFC3339)))
+	}
+	if !query.Before.IsZero() {
+		filters = append(filters, fmt.Sprintf("receivedDateTime lt %s", query.Before.UTC().Format(time.RFC3339)))
+	}
+	if query.HasAttachment {
+		filters = append(filters, "hasAttachments eq true")
+	}
+
+	endpoint := fmt.Sprintf("%s/me/mailFolders/%s/messages", graphBaseURL, url.PathEscape(folder))
+	params := url.Values{}
+	params.Set("$top", fmt.Sprintf("%d", limit))
+	params.Set("$orderby", "receivedDateTime desc")
+	params.Set("$select", "id,from,toRecipients,subject,receivedDateTime,isRead,hasAttachments,internetMessageId")
+
+	// Use $search for free-text query (requires ConsistencyLevel: eventual)
+	if query.Query != "" {
+		params.Set("$search", fmt.Sprintf(`"%s"`, escapeOData(query.Query)))
+	}
+	if len(filters) > 0 {
+		params.Set("$filter", strings.Join(filters, " and "))
+	}
+
+	var result graphMessageList
+	if err := c.graphGetWithHeaders(ctx, endpoint+"?"+params.Encode(), map[string]string{
+		"ConsistencyLevel": "eventual",
+	}, &result); err != nil {
+		return nil, fmt.Errorf("msgraph: search messages: %w", err)
+	}
+
+	summaries := make([]MessageSummary, 0, len(result.Value))
+	for _, m := range result.Value {
+		summaries = append(summaries, m.toSummary())
+	}
+	return summaries, nil
+}
+
+// Send sends a new email via Microsoft Graph.
+func (c *MSGraphClient) Send(ctx context.Context, msg OutgoingMessage) (string, error) {
+	payload := buildSendMailPayload(msg)
+
+	endpoint := graphBaseURL + "/me/sendMail"
+	if err := c.graphPost(ctx, endpoint, payload); err != nil {
+		return "", fmt.Errorf("msgraph: send mail: %w", err)
+	}
+
+	// Graph API doesn't return the Message-ID directly from sendMail.
+	// Generate one for tracking purposes.
+	domain := ExtractSenderDomain(c.cfg.Address)
+	return BuildMessageID(domain), nil
+}
+
+// Reply sends a reply to an existing email.
+func (c *MSGraphClient) Reply(ctx context.Context, replyToID string, replyAll bool, msg OutgoingMessage) (string, error) {
+	action := "reply"
+	if replyAll {
+		action = "replyAll"
+	}
+
+	payload := map[string]any{
+		"comment": msg.Body,
+	}
+
+	// If the user specified custom recipients or subject, use createReply + send pattern
+	if len(msg.To) > 0 || msg.Subject != "" || msg.HTML != "" {
+		return c.replyWithCustomContent(ctx, replyToID, replyAll, msg)
+	}
+
+	endpoint := fmt.Sprintf("%s/me/messages/%s/%s", graphBaseURL, url.PathEscape(replyToID), action)
+	if err := c.graphPost(ctx, endpoint, payload); err != nil {
+		return "", fmt.Errorf("msgraph: reply: %w", err)
+	}
+
+	domain := ExtractSenderDomain(c.cfg.Address)
+	return BuildMessageID(domain), nil
+}
+
+// replyWithCustomContent creates a draft reply, modifies it, then sends.
+func (c *MSGraphClient) replyWithCustomContent(ctx context.Context, replyToID string, replyAll bool, msg OutgoingMessage) (string, error) {
+	action := "createReply"
+	if replyAll {
+		action = "createReplyAll"
+	}
+
+	// Step 1: Create draft reply
+	endpoint := fmt.Sprintf("%s/me/messages/%s/%s", graphBaseURL, url.PathEscape(replyToID), action)
+	var draft graphMessage
+	if err := c.graphPostDecode(ctx, endpoint, nil, &draft); err != nil {
+		return "", fmt.Errorf("msgraph: create draft reply: %w", err)
+	}
+
+	// Step 2: Update the draft with custom content
+	update := map[string]any{}
+	if msg.HTML != "" {
+		update["body"] = map[string]string{
+			"contentType": "HTML",
+			"content":     msg.HTML,
+		}
+	} else if msg.Body != "" {
+		update["body"] = map[string]string{
+			"contentType": "Text",
+			"content":     msg.Body,
+		}
+	}
+	if msg.Subject != "" {
+		update["subject"] = msg.Subject
+	}
+	if len(msg.To) > 0 {
+		update["toRecipients"] = buildRecipients(msg.To)
+	}
+	if len(msg.CC) > 0 {
+		update["ccRecipients"] = buildRecipients(msg.CC)
+	}
+
+	if len(update) > 0 {
+		patchEndpoint := fmt.Sprintf("%s/me/messages/%s", graphBaseURL, url.PathEscape(draft.ID))
+		if err := c.graphPatch(ctx, patchEndpoint, update); err != nil {
+			return "", fmt.Errorf("msgraph: update draft reply: %w", err)
+		}
+	}
+
+	// Step 3: Send the draft
+	sendEndpoint := fmt.Sprintf("%s/me/messages/%s/send", graphBaseURL, url.PathEscape(draft.ID))
+	if err := c.graphPost(ctx, sendEndpoint, nil); err != nil {
+		return "", fmt.Errorf("msgraph: send draft reply: %w", err)
+	}
+
+	domain := ExtractSenderDomain(c.cfg.Address)
+	return BuildMessageID(domain), nil
+}
+
+// MarkRead marks the given messages as read.
+func (c *MSGraphClient) MarkRead(ctx context.Context, ids []string) error {
+	return c.setReadStatus(ctx, ids, true)
+}
+
+// MarkUnread marks the given messages as unread.
+func (c *MSGraphClient) MarkUnread(ctx context.Context, ids []string) error {
+	return c.setReadStatus(ctx, ids, false)
+}
+
+func (c *MSGraphClient) setReadStatus(ctx context.Context, ids []string, isRead bool) error {
+	for _, id := range ids {
+		endpoint := fmt.Sprintf("%s/me/messages/%s", graphBaseURL, url.PathEscape(id))
+		payload := map[string]any{"isRead": isRead}
+		if err := c.graphPatch(ctx, endpoint, payload); err != nil {
+			return fmt.Errorf("msgraph: set read status for %s: %w", id, err)
+		}
+	}
+	return nil
+}
+
+// Delete moves messages to trash or permanently deletes them.
+func (c *MSGraphClient) Delete(ctx context.Context, ids []string, permanent bool) error {
+	for _, id := range ids {
+		if permanent {
+			endpoint := fmt.Sprintf("%s/me/messages/%s", graphBaseURL, url.PathEscape(id))
+			if err := c.graphDelete(ctx, endpoint); err != nil {
+				return fmt.Errorf("msgraph: delete %s: %w", id, err)
+			}
+		} else {
+			// Move to Deleted Items
+			endpoint := fmt.Sprintf("%s/me/messages/%s/move", graphBaseURL, url.PathEscape(id))
+			payload := map[string]string{"destinationId": "deleteditems"}
+			if err := c.graphPost(ctx, endpoint, payload); err != nil {
+				return fmt.Errorf("msgraph: move to trash %s: %w", id, err)
+			}
+		}
+	}
+	return nil
+}
+
+// --- HTTP helpers ---
+
+func (c *MSGraphClient) graphGet(ctx context.Context, url string, dest any) error {
+	return c.graphGetWithHeaders(ctx, url, nil, dest)
+}
+
+func (c *MSGraphClient) graphGetWithHeaders(ctx context.Context, url string, headers map[string]string, dest any) error {
+	token, err := c.tokenFunc()
+	if err != nil {
+		return fmt.Errorf("obtain token: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return parseGraphError(resp)
+	}
+
+	if dest != nil {
+		if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *MSGraphClient) graphPost(ctx context.Context, url string, payload any) error {
+	return c.graphRequest(ctx, "POST", url, payload, nil)
+}
+
+func (c *MSGraphClient) graphPostDecode(ctx context.Context, url string, payload any, dest any) error {
+	return c.graphRequest(ctx, "POST", url, payload, dest)
+}
+
+func (c *MSGraphClient) graphPatch(ctx context.Context, url string, payload any) error {
+	return c.graphRequest(ctx, "PATCH", url, payload, nil)
+}
+
+func (c *MSGraphClient) graphDelete(ctx context.Context, url string) error {
+	return c.graphRequest(ctx, "DELETE", url, nil, nil)
+}
+
+func (c *MSGraphClient) graphRequest(ctx context.Context, method, url string, payload any, dest any) error {
+	token, err := c.tokenFunc()
+	if err != nil {
+		return fmt.Errorf("obtain token: %w", err)
+	}
+
+	var body io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal payload: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Accept 2xx responses
+	if resp.StatusCode >= 300 {
+		return parseGraphError(resp)
+	}
+
+	if dest != nil {
+		if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+func parseGraphError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	var graphErr struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &graphErr) == nil && graphErr.Error.Message != "" {
+		return fmt.Errorf("Graph API %d %s: %s", resp.StatusCode, graphErr.Error.Code, graphErr.Error.Message)
+	}
+	return fmt.Errorf("Graph API %d: %s", resp.StatusCode, string(body))
+}
+
+// --- Graph API data models ---
+
+type graphMessageList struct {
+	Value    []graphMessage `json:"value"`
+	NextLink string         `json:"@odata.nextLink,omitempty"`
+}
+
+type graphMessage struct {
+	ID                     string              `json:"id"`
+	Subject                string              `json:"subject"`
+	ReceivedDateTime       string              `json:"receivedDateTime"`
+	IsRead                 bool                `json:"isRead"`
+	HasAttachments         bool                `json:"hasAttachments"`
+	InternetMessageID      string              `json:"internetMessageId"`
+	From                   *graphEmailAddress  `json:"from"`
+	ToRecipients           []graphRecipient    `json:"toRecipients"`
+	CcRecipients           []graphRecipient    `json:"ccRecipients"`
+	Body                   *graphBody          `json:"body"`
+	InternetMessageHeaders []graphHeader       `json:"internetMessageHeaders"`
+	Attachments            []graphAttachment   `json:"attachments"`
+}
+
+type graphEmailAddress struct {
+	EmailAddress struct {
+		Name    string `json:"name"`
+		Address string `json:"address"`
+	} `json:"emailAddress"`
+}
+
+type graphRecipient struct {
+	EmailAddress struct {
+		Name    string `json:"name"`
+		Address string `json:"address"`
+	} `json:"emailAddress"`
+}
+
+type graphBody struct {
+	ContentType string `json:"contentType"` // "text" or "html"
+	Content     string `json:"content"`
+}
+
+type graphHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type graphAttachment struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"contentType"`
+	IsInline    bool   `json:"isInline"`
+}
+
+// --- Conversion helpers ---
+
+func (m *graphMessage) toSummary() MessageSummary {
+	s := MessageSummary{
+		ID:             m.ID,
+		Subject:        m.Subject,
+		Unread:         !m.IsRead,
+		HasAttachments: m.HasAttachments,
+		MessageID:      m.InternetMessageID,
+	}
+
+	if m.From != nil {
+		s.From = formatGraphAddress(m.From.EmailAddress.Name, m.From.EmailAddress.Address)
+	}
+	for _, r := range m.ToRecipients {
+		s.To = append(s.To, r.EmailAddress.Address)
+	}
+	if t, err := time.Parse(time.RFC3339, m.ReceivedDateTime); err == nil {
+		s.Date = t
+	}
+
+	// Extract In-Reply-To from internet message headers
+	for _, h := range m.InternetMessageHeaders {
+		if strings.EqualFold(h.Name, "In-Reply-To") {
+			s.InReplyTo = h.Value
+			break
+		}
+	}
+
+	return s
+}
+
+func (m *graphMessage) toMessage(maxBodyChars int) *Message {
+	msg := &Message{
+		ID:      m.ID,
+		Subject: m.Subject,
+		Unread:  !m.IsRead,
+		Headers: make(map[string]string),
+	}
+
+	if m.From != nil {
+		msg.From = formatGraphAddress(m.From.EmailAddress.Name, m.From.EmailAddress.Address)
+	}
+	for _, r := range m.ToRecipients {
+		msg.To = append(msg.To, r.EmailAddress.Address)
+	}
+	for _, r := range m.CcRecipients {
+		msg.CC = append(msg.CC, r.EmailAddress.Address)
+	}
+	if t, err := time.Parse(time.RFC3339, m.ReceivedDateTime); err == nil {
+		msg.Date = t
+	}
+
+	// Body
+	if m.Body != nil {
+		if strings.EqualFold(m.Body.ContentType, "html") {
+			msg.HTML = m.Body.Content
+			msg.Body = stripHTMLBasic(m.Body.Content)
+		} else {
+			msg.Body = m.Body.Content
+		}
+	}
+
+	// Truncate body if configured
+	if maxBodyChars > 0 {
+		if len(msg.Body) > maxBodyChars {
+			msg.Body = msg.Body[:maxBodyChars]
+		}
+		if len(msg.HTML) > maxBodyChars {
+			msg.HTML = msg.HTML[:maxBodyChars]
+		}
+	}
+
+	// Headers from internet message headers
+	msg.Headers["Message-ID"] = m.InternetMessageID
+	for _, h := range m.InternetMessageHeaders {
+		switch strings.ToLower(h.Name) {
+		case "in-reply-to":
+			msg.Headers["In-Reply-To"] = h.Value
+		case "references":
+			msg.Headers["References"] = h.Value
+		case "message-id":
+			msg.Headers["Message-ID"] = h.Value
+		}
+	}
+
+	// Attachments
+	for _, a := range m.Attachments {
+		if a.IsInline {
+			continue
+		}
+		msg.Attachments = append(msg.Attachments, AttachmentInfo{
+			Name:        a.Name,
+			Size:        a.Size,
+			ContentType: a.ContentType,
+		})
+	}
+
+	// Extract links from body
+	msg.Links = extractLinks(msg.Body + " " + msg.HTML)
+
+	return msg
+}
+
+// --- Payload builders ---
+
+func buildSendMailPayload(msg OutgoingMessage) map[string]any {
+	body := map[string]string{}
+	if msg.HTML != "" {
+		body["contentType"] = "HTML"
+		body["content"] = msg.HTML
+	} else {
+		body["contentType"] = "Text"
+		body["content"] = msg.Body
+	}
+
+	message := map[string]any{
+		"subject":      msg.Subject,
+		"body":         body,
+		"toRecipients": buildRecipients(msg.To),
+	}
+	if len(msg.CC) > 0 {
+		message["ccRecipients"] = buildRecipients(msg.CC)
+	}
+	if msg.ReplyTo != "" {
+		message["replyTo"] = []map[string]any{
+			{"emailAddress": map[string]string{"address": msg.ReplyTo}},
+		}
+	}
+
+	payload := map[string]any{
+		"message":         message,
+		"saveToSentItems": true,
+	}
+
+	return payload
+}
+
+func buildRecipients(addrs []string) []map[string]any {
+	recipients := make([]map[string]any, 0, len(addrs))
+	for _, addr := range addrs {
+		recipients = append(recipients, map[string]any{
+			"emailAddress": map[string]string{"address": addr},
+		})
+	}
+	return recipients
+}
+
+func formatGraphAddress(name, address string) string {
+	if name != "" && name != address {
+		return fmt.Sprintf("%s <%s>", name, address)
+	}
+	return address
+}
+
+// escapeOData escapes single quotes in OData filter values.
+func escapeOData(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// stripHTMLBasic does a very basic HTML-to-text conversion (strips tags).
+// For full conversion, the existing parser.go functions can be used.
+func stripHTMLBasic(html string) string {
+	var result strings.Builder
+	inTag := false
+	for _, r := range html {
+		switch {
+		case r == '<':
+			inTag = true
+		case r == '>':
+			inTag = false
+		case !inTag:
+			result.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(result.String())
+}
+
+// extractLinks extracts URLs from text content.
+func extractLinks(text string) []string {
+	var links []string
+	seen := make(map[string]bool)
+	for _, word := range strings.Fields(text) {
+		// Clean common trailing punctuation
+		word = strings.TrimRight(word, ".,;:!?\"')")
+		if (strings.HasPrefix(word, "http://") || strings.HasPrefix(word, "https://")) && !seen[word] {
+			links = append(links, word)
+			seen[word] = true
+		}
+	}
+	return links
+}

--- a/pkg/email/msgraph.go
+++ b/pkg/email/msgraph.go
@@ -747,10 +747,12 @@ type MSGraphTokenResponse struct {
 func ExchangeMSGraphToken(ctx context.Context, tokenURL, clientID, clientSecret, refreshToken string) (*MSGraphTokenResponse, error) {
 	data := url.Values{
 		"client_id":     {clientID},
-		"client_secret": {clientSecret},
 		"refresh_token": {refreshToken},
 		"grant_type":    {"refresh_token"},
 		"scope":         {"https://graph.microsoft.com/.default"},
+	}
+	if clientSecret != "" {
+		data.Set("client_secret", clientSecret)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(data.Encode()))

--- a/pkg/email/msgraph.go
+++ b/pkg/email/msgraph.go
@@ -730,3 +730,54 @@ func extractLinks(text string) []string {
 	}
 	return links
 }
+
+// --- Token Exchange ---
+
+// MSGraphTokenResponse is the response from the Microsoft identity token endpoint.
+type MSGraphTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
+// ExchangeMSGraphToken exchanges a refresh token for a new access token (and
+// possibly a rotated refresh token) using the Microsoft identity platform.
+// The tokenURL should be https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token.
+func ExchangeMSGraphToken(ctx context.Context, tokenURL, clientID, clientSecret, refreshToken string) (*MSGraphTokenResponse, error) {
+	data := url.Values{
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"refresh_token": {refreshToken},
+		"grant_type":    {"refresh_token"},
+		"scope":         {"https://graph.microsoft.com/.default offline_access"},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp MSGraphTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("parse token response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("token response missing access_token")
+	}
+	return &tokenResp, nil
+}

--- a/pkg/email/msgraph_test.go
+++ b/pkg/email/msgraph_test.go
@@ -1,0 +1,323 @@
+package email
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMSGraphClient_Connect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1.0/me" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+			t.Errorf("unexpected auth header: %s", auth)
+		}
+		json.NewEncoder(w).Encode(map[string]string{"mail": "test@example.com"})
+	}))
+	defer srv.Close()
+
+	// Override graphBaseURL for testing — we'll use a custom client
+	client := newTestClient(srv, "test-token")
+
+	err := client.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect() error: %v", err)
+	}
+	if !client.IsConnected() {
+		t.Error("expected IsConnected()=true after Connect()")
+	}
+}
+
+func TestMSGraphClient_Connect_TokenError(t *testing.T) {
+	client := &MSGraphClient{
+		cfg:       &Config{Address: "test@example.com"},
+		tokenFunc: func() (string, error) { return "", fmt.Errorf("token expired") },
+		client:    http.DefaultClient,
+	}
+
+	err := client.Connect(context.Background())
+	if err == nil {
+		t.Fatal("expected error from Connect() when token fails")
+	}
+	if !strings.Contains(err.Error(), "token") {
+		t.Errorf("expected token error, got: %v", err)
+	}
+}
+
+func TestMSGraphClient_ListMessages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/mailFolders/Inbox/messages") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		resp := graphMessageList{
+			Value: []graphMessage{
+				{
+					ID:               "msg-1",
+					Subject:          "Hello",
+					ReceivedDateTime: "2025-01-15T10:30:00Z",
+					IsRead:           false,
+					HasAttachments:   true,
+					InternetMessageID: "<abc@example.com>",
+					From: &graphEmailAddress{},
+					ToRecipients: []graphRecipient{
+						{},
+					},
+				},
+			},
+		}
+		resp.Value[0].From.EmailAddress.Address = "sender@example.com"
+		resp.Value[0].From.EmailAddress.Name = "Sender"
+		resp.Value[0].ToRecipients[0].EmailAddress.Address = "test@example.com"
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv, "test-token")
+	client.connected = true
+
+	msgs, err := client.ListMessages(context.Background(), ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages() error: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].ID != "msg-1" {
+		t.Errorf("expected ID=msg-1, got %s", msgs[0].ID)
+	}
+	if msgs[0].Subject != "Hello" {
+		t.Errorf("expected Subject=Hello, got %s", msgs[0].Subject)
+	}
+	if !msgs[0].Unread {
+		t.Error("expected Unread=true")
+	}
+	if !msgs[0].HasAttachments {
+		t.Error("expected HasAttachments=true")
+	}
+}
+
+func TestMSGraphClient_ReadMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/me/messages/msg-42") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		resp := graphMessage{
+			ID:               "msg-42",
+			Subject:          "Test Email",
+			ReceivedDateTime: "2025-06-01T12:00:00Z",
+			IsRead:           true,
+			From:             &graphEmailAddress{},
+			Body: &graphBody{
+				ContentType: "text",
+				Content:     "Hello, this is a test.",
+			},
+			Attachments: []graphAttachment{
+				{ID: "att-1", Name: "file.pdf", Size: 1024, ContentType: "application/pdf"},
+			},
+		}
+		resp.From.EmailAddress.Address = "someone@example.com"
+		resp.From.EmailAddress.Name = "Someone"
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv, "test-token")
+	client.connected = true
+
+	msg, err := client.ReadMessage(context.Background(), "msg-42")
+	if err != nil {
+		t.Fatalf("ReadMessage() error: %v", err)
+	}
+	if msg.ID != "msg-42" {
+		t.Errorf("expected ID=msg-42, got %s", msg.ID)
+	}
+	if msg.Body != "Hello, this is a test." {
+		t.Errorf("unexpected body: %s", msg.Body)
+	}
+	if len(msg.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(msg.Attachments))
+	}
+	if msg.Attachments[0].Name != "file.pdf" {
+		t.Errorf("expected attachment name=file.pdf, got %s", msg.Attachments[0].Name)
+	}
+}
+
+func TestMSGraphClient_Send(t *testing.T) {
+	var receivedPayload map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1.0/me/sendMail" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		json.NewDecoder(r.Body).Decode(&receivedPayload)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv, "test-token")
+	client.connected = true
+
+	msgID, err := client.Send(context.Background(), OutgoingMessage{
+		To:      []string{"recipient@example.com"},
+		Subject: "Test Subject",
+		Body:    "Hello!",
+	})
+	if err != nil {
+		t.Fatalf("Send() error: %v", err)
+	}
+	if msgID == "" {
+		t.Error("expected non-empty message ID")
+	}
+
+	// Verify payload structure
+	msg, ok := receivedPayload["message"].(map[string]any)
+	if !ok {
+		t.Fatal("expected message in payload")
+	}
+	if msg["subject"] != "Test Subject" {
+		t.Errorf("unexpected subject: %v", msg["subject"])
+	}
+}
+
+func TestMSGraphClient_MarkRead(t *testing.T) {
+	var patchedIDs []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PATCH" {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		// Extract message ID from path
+		parts := strings.Split(r.URL.Path, "/")
+		patchedIDs = append(patchedIDs, parts[len(parts)-1])
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["isRead"] != true {
+			t.Errorf("expected isRead=true, got %v", body["isRead"])
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv, "test-token")
+	client.connected = true
+
+	err := client.MarkRead(context.Background(), []string{"msg-1", "msg-2"})
+	if err != nil {
+		t.Fatalf("MarkRead() error: %v", err)
+	}
+	if len(patchedIDs) != 2 {
+		t.Errorf("expected 2 patches, got %d", len(patchedIDs))
+	}
+}
+
+func TestMSGraphClient_Delete(t *testing.T) {
+	var deletedPaths []string
+	var movedPaths []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" {
+			deletedPaths = append(deletedPaths, r.URL.Path)
+		} else if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/move") {
+			movedPaths = append(movedPaths, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv, "test-token")
+	client.connected = true
+
+	// Test soft delete (move to trash)
+	err := client.Delete(context.Background(), []string{"msg-1"}, false)
+	if err != nil {
+		t.Fatalf("Delete(permanent=false) error: %v", err)
+	}
+	if len(movedPaths) != 1 {
+		t.Errorf("expected 1 move, got %d", len(movedPaths))
+	}
+
+	// Test permanent delete
+	err = client.Delete(context.Background(), []string{"msg-2"}, true)
+	if err != nil {
+		t.Fatalf("Delete(permanent=true) error: %v", err)
+	}
+	if len(deletedPaths) != 1 {
+		t.Errorf("expected 1 delete, got %d", len(deletedPaths))
+	}
+}
+
+func TestMSGraphClient_GraphError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{
+				"code":    "ErrorAccessDenied",
+				"message": "Access is denied. Check credentials and try again.",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv, "test-token")
+
+	err := client.Connect(context.Background())
+	if err == nil {
+		t.Fatal("expected error from Connect() with 403")
+	}
+	if !strings.Contains(err.Error(), "ErrorAccessDenied") {
+		t.Errorf("expected ErrorAccessDenied in error, got: %v", err)
+	}
+}
+
+// --- Test helpers ---
+
+// newTestClient creates an MSGraphClient pointing at a test server.
+// It overrides the graphBaseURL by using a custom HTTP client transport.
+func newTestClient(srv *httptest.Server, token string) *MSGraphClient {
+	// We override the base URL by intercepting requests
+	client := &MSGraphClient{
+		cfg:       &Config{Address: "test@example.com", MaxBodyChars: 50000},
+		tokenFunc: func() (string, error) { return token, nil },
+		client:    srv.Client(),
+	}
+	// Replace the graphBaseURL in all method calls by using a redirect-based approach
+	// Actually, we need to directly patch the URLs. Let's create a wrapper.
+	// The simplest approach: override the test to use a URL-rewriting transport.
+	client.client.Transport = &testTransport{
+		base:     srv.Client().Transport,
+		serverURL: srv.URL + "/v1.0",
+	}
+	return client
+}
+
+// testTransport rewrites Graph API URLs to point at the test server.
+type testTransport struct {
+	base      http.RoundTripper
+	serverURL string
+}
+
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace https://graph.microsoft.com/v1.0 with test server URL
+	if strings.HasPrefix(req.URL.String(), graphBaseURL) {
+		newURL := strings.Replace(req.URL.String(), graphBaseURL, t.serverURL, 1)
+		var err error
+		req.URL, err = req.URL.Parse(newURL)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if t.base != nil {
+		return t.base.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/pkg/store/entstore/platform_settings.go
+++ b/pkg/store/entstore/platform_settings.go
@@ -230,14 +230,20 @@ func (s *Store) Secrets() *PlatformSecretsStore {
 	return &PlatformSecretsStore{client: s.platformClient}
 }
 
-// GetSecret returns the secret value for the given key, or "" if not found.
+// GetSecret returns the decrypted secret value for the given key, or "" if not found.
 func (ps *PlatformSecretsStore) GetSecret(key string) string {
 	ctx := context.Background()
 	row, err := ps.client.PlatformSecret.Get(ctx, key)
 	if err != nil {
 		return ""
 	}
-	return string(row.Value)
+	masterKey := loadMasterKey()
+	plaintext, err := decryptSecret(row.Value, masterKey)
+	if err != nil {
+		slog.Warn("failed to decrypt platform secret", "key", key, "error", err)
+		return ""
+	}
+	return string(plaintext)
 }
 
 // SetSecret stores a secret value. Creates or updates the entry.

--- a/pkg/store/settings.go
+++ b/pkg/store/settings.go
@@ -58,11 +58,12 @@ type PlatformTelegramConfig struct {
 // PlatformEmailConfig holds non-secret Email channel settings.
 type PlatformEmailConfig struct {
 	Enabled      bool   `json:"enabled"`
-	Provider     string `json:"provider,omitempty"`      // "imap" (default) or "gmail"
+	Provider     string `json:"provider,omitempty"`      // "imap" (default), "gmail", or "msgraph"
 	IMAPServer   string `json:"imap_server"`             // e.g. "imap.gmail.com:993"
 	SMTPServer   string `json:"smtp_server"`             // e.g. "smtp.gmail.com:587"
 	Address      string `json:"address"`                 // agent's email address
 	Username     string `json:"username,omitempty"`      // login username (defaults to address)
+	Credential   string `json:"credential,omitempty"`    // credential store name (for msgraph provider)
 	PollInterval int    `json:"poll_interval,omitempty"` // seconds, default 30
 	Folder       string `json:"folder,omitempty"`        // default "INBOX"
 	MarkRead     *bool  `json:"mark_read,omitempty"`     // default true

--- a/web/src/api/platformAdmin.ts
+++ b/web/src/api/platformAdmin.ts
@@ -352,6 +352,15 @@ export async function deleteChannel(channelType: string): Promise<{ message: str
   return res.json()
 }
 
+export async function testEmailConnection(): Promise<{ status: string; message: string; email?: string; displayName?: string }> {
+  const res = await adminFetch(`${ADMIN_BASE}/channels/email/test`, {
+    method: 'POST',
+    credentials: 'include',
+  })
+  await throwIfNotOk(res, 'Failed to test email connection')
+  return res.json()
+}
+
 // --- Web Services (Standard MCP Servers) ---
 
 export interface WebServiceInfo {

--- a/web/src/api/platformAdmin.ts
+++ b/web/src/api/platformAdmin.ts
@@ -352,10 +352,12 @@ export async function deleteChannel(channelType: string): Promise<{ message: str
   return res.json()
 }
 
-export async function testEmailConnection(): Promise<{ status: string; message: string; email?: string; displayName?: string }> {
+export async function testEmailConnection(secrets?: Record<string, string>): Promise<{ status: string; message: string; email?: string; displayName?: string }> {
   const res = await adminFetch(`${ADMIN_BASE}/channels/email/test`, {
     method: 'POST',
     credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ secrets: secrets || {} }),
   })
   await throwIfNotOk(res, 'Failed to test email connection')
   return res.json()

--- a/web/src/components/platformAdmin/ChannelsTab.tsx
+++ b/web/src/components/platformAdmin/ChannelsTab.tsx
@@ -181,11 +181,11 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
           )}
 
           {/* Secrets (hidden for msgraph which uses credential store) */}
-          {channel.secrets.length > 0 && !(channel.type === 'email' && form.provider === 'msgraph') && (
+          {(channel.secrets || []).length > 0 && !(channel.type === 'email' && form.provider === 'msgraph') && (
           <div className="pt-2">
             <label className="block text-xs font-semibold mb-2" style={{ color: 'var(--text-secondary)' }}>Credentials</label>
             <div className="space-y-2">
-              {channel.secrets.map(s => (
+              {(channel.secrets || []).map(s => (
                 <div key={s.key}>
                   <label className="block text-xs mb-1" style={{ color: 'var(--text-muted)' }}>
                     {s.label}

--- a/web/src/components/platformAdmin/ChannelsTab.tsx
+++ b/web/src/components/platformAdmin/ChannelsTab.tsx
@@ -180,8 +180,8 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
             <SlackConfigFields form={form} setForm={setForm} />
           )}
 
-          {/* Secrets (hidden for msgraph which uses credential store) */}
-          {(channel.secrets || []).length > 0 && !(channel.type === 'email' && form.provider === 'msgraph') && (
+          {/* Secrets */}
+          {(channel.secrets || []).length > 0 && (
           <div className="pt-2">
             <label className="block text-xs font-semibold mb-2" style={{ color: 'var(--text-secondary)' }}>Credentials</label>
             <div className="space-y-2">
@@ -331,25 +331,6 @@ function EmailConfigFields({ form, setForm }: EmailConfigFieldsProps) {
           </div>
         )}
       </div>
-
-      {/* Microsoft Graph credential field */}
-      {isMSGraph && (
-        <div>
-          <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Credential Name</label>
-          <input
-            type="text"
-            value={form.credential || ''}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => update('credential', e.target.value)}
-            placeholder="email-microsoft"
-            className="w-full px-3 py-2 rounded-lg text-xs outline-none font-mono"
-            style={inputStyle}
-          />
-          <p className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>
-            Name of the credential (type: oauth_authorization_code) containing your
-            Microsoft 365 refresh token, client ID, and client secret.
-          </p>
-        </div>
-      )}
 
       {/* Behavior settings */}
       <div className="grid grid-cols-3 gap-3">

--- a/web/src/components/platformAdmin/ChannelsTab.tsx
+++ b/web/src/components/platformAdmin/ChannelsTab.tsx
@@ -181,29 +181,52 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
           )}
 
           {/* Secrets */}
-          {(channel.secrets || []).length > 0 && (
-          <div className="pt-2">
-            <label className="block text-xs font-semibold mb-2" style={{ color: 'var(--text-secondary)' }}>Credentials</label>
-            <div className="space-y-2">
-              {(channel.secrets || []).map(s => (
-                <div key={s.key}>
-                  <label className="block text-xs mb-1" style={{ color: 'var(--text-muted)' }}>
-                    {s.label}
-                    {s.configured && <span className="ml-1.5 text-xs" style={{ color: '#22c55e' }}>&#9679;</span>}
-                  </label>
-                  <input
-                    type="password"
-                    value={secrets[s.key] || ''}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => setSecrets(prev => ({ ...prev, [s.key]: e.target.value }))}
-                    placeholder={s.configured ? '(set -- leave blank to keep)' : 'Enter value...'}
-                    className="w-full px-3 py-2 rounded-lg text-xs outline-none font-mono"
-                    style={inputStyle}
-                  />
+          {(() => {
+            // For email channels, determine secrets based on the currently selected provider
+            // (not the saved one from backend) so the UI updates immediately on dropdown change.
+            const emailSecretsByProvider: Record<string, { key: string; label: string }[]> = {
+              imap: [{ key: 'channels.email.password', label: 'IMAP/SMTP Password' }],
+              gmail: [{ key: 'channels.email.password', label: 'IMAP/SMTP Password' }],
+              msgraph: [
+                { key: 'channels.email.tenant_id', label: 'Tenant ID' },
+                { key: 'channels.email.client_id', label: 'Client ID' },
+                { key: 'channels.email.client_secret', label: 'Client Secret' },
+                { key: 'channels.email.refresh_token', label: 'Refresh Token' },
+              ],
+            }
+            const secretsList = channel.type === 'email'
+              ? (emailSecretsByProvider[form.provider || 'imap'] || emailSecretsByProvider.imap)
+              : (channel.secrets || [])
+            // Build a lookup for "configured" status from backend data
+            const configuredMap: Record<string, boolean> = {}
+            for (const s of (channel.secrets || [])) {
+              configuredMap[s.key] = s.configured
+            }
+            if (secretsList.length === 0) return null
+            return (
+              <div className="pt-2">
+                <label className="block text-xs font-semibold mb-2" style={{ color: 'var(--text-secondary)' }}>Credentials</label>
+                <div className="space-y-2">
+                  {secretsList.map((s: { key: string; label: string }) => (
+                    <div key={s.key}>
+                      <label className="block text-xs mb-1" style={{ color: 'var(--text-muted)' }}>
+                        {s.label}
+                        {configuredMap[s.key] && <span className="ml-1.5 text-xs" style={{ color: '#22c55e' }}>&#9679;</span>}
+                      </label>
+                      <input
+                        type="password"
+                        value={secrets[s.key] || ''}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => setSecrets(prev => ({ ...prev, [s.key]: e.target.value }))}
+                        placeholder={configuredMap[s.key] ? '(set -- leave blank to keep)' : 'Enter value...'}
+                        className="w-full px-3 py-2 rounded-lg text-xs outline-none font-mono"
+                        style={inputStyle}
+                      />
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </div>
-          )}
+              </div>
+            )
+          })()}
 
           {/* Actions */}
           <div className="flex items-center justify-between pt-3" style={{ borderTop: '1px solid var(--border-color)' }}>

--- a/web/src/components/platformAdmin/ChannelsTab.tsx
+++ b/web/src/components/platformAdmin/ChannelsTab.tsx
@@ -81,6 +81,8 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
   const [secrets, setSecrets] = useState<Record<string, string>>({})
   const [enabled, setEnabled] = useState<boolean>(channel.enabled)
   const [saving, setSaving] = useState<boolean>(false)
+  const [testing, setTesting] = useState<boolean>(false)
+  const [testResult, setTestResult] = useState<{ status: string; message: string; email?: string } | null>(null)
 
   useEffect(() => {
     setForm({ ...channel.config })
@@ -111,6 +113,19 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
       onDeleted(result.message)
     } catch (e) {
       onError((e as Error).message)
+    }
+  }
+
+  const handleTestConnection = async () => {
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const result = await adminApi.testEmailConnection()
+      setTestResult(result)
+    } catch (e) {
+      setTestResult({ status: 'error', message: (e as Error).message })
+    } finally {
+      setTesting(false)
     }
   }
 
@@ -193,11 +208,28 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
             <button onClick={handleDelete} className="px-3 py-2 rounded-lg text-xs font-medium" style={{ color: '#ef4444' }}>
               <Trash2 size={12} className="inline mr-1" />Remove Channel
             </button>
-            <button onClick={handleSave} disabled={saving} className="px-4 py-2 rounded-lg text-xs font-medium text-white" style={{ background: 'var(--accent)' }}>
-              {saving ? <Loader2 size={12} className="animate-spin inline mr-1" /> : null}
-              Save & Apply
-            </button>
+            <div className="flex items-center gap-2">
+              {channel.type === 'email' && (
+                <button onClick={handleTestConnection} disabled={testing} className="px-3 py-2 rounded-lg text-xs font-medium" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-color)' }}>
+                  {testing ? <Loader2 size={12} className="animate-spin inline mr-1" /> : null}
+                  {testing ? 'Testing...' : 'Test Connection'}
+                </button>
+              )}
+              <button onClick={handleSave} disabled={saving} className="px-4 py-2 rounded-lg text-xs font-medium text-white" style={{ background: 'var(--accent)' }}>
+                {saving ? <Loader2 size={12} className="animate-spin inline mr-1" /> : null}
+                Save & Apply
+              </button>
+            </div>
           </div>
+          {/* Test result */}
+          {testResult && (
+            <div className="text-xs px-2 py-1 rounded" style={{
+              color: testResult.status === 'ok' ? '#22c55e' : '#ef4444',
+              background: testResult.status === 'ok' ? '#22c55e15' : '#ef444415',
+            }}>
+              {testResult.message}{testResult.email ? ' (' + testResult.email + ')' : ''}
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -223,34 +255,55 @@ interface EmailConfigFieldsProps {
 
 function EmailConfigFields({ form, setForm }: EmailConfigFieldsProps) {
   const update = (key: string, value: string | number | boolean) => setForm({ ...form, [key]: value })
+  const isMSGraph = (form.provider || 'imap') === 'msgraph'
 
   return (
     <div className="space-y-3">
-      <div className="grid grid-cols-2 gap-3">
-        <div>
-          <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>IMAP Server</label>
-          <input
-            type="text"
-            value={form.imap_server || ''}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => update('imap_server', e.target.value)}
-            placeholder="imap.gmail.com:993"
-            className="w-full px-3 py-2 rounded-lg text-xs outline-none"
-            style={inputStyle}
-          />
-        </div>
-        <div>
-          <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>SMTP Server</label>
-          <input
-            type="text"
-            value={form.smtp_server || ''}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => update('smtp_server', e.target.value)}
-            placeholder="smtp.gmail.com:587"
-            className="w-full px-3 py-2 rounded-lg text-xs outline-none"
-            style={inputStyle}
-          />
-        </div>
+      {/* Provider selection - prominent at the top */}
+      <div>
+        <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Provider</label>
+        <select
+          value={form.provider || 'imap'}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => update('provider', e.target.value)}
+          className="w-full px-3 py-2 rounded-lg text-xs outline-none"
+          style={inputStyle}
+        >
+          <option value="imap">IMAP/SMTP</option>
+          <option value="gmail">Gmail (IMAP/SMTP)</option>
+          <option value="msgraph">Microsoft 365 (Graph API)</option>
+        </select>
       </div>
-      <div className="grid grid-cols-2 gap-3">
+
+      {/* IMAP/SMTP fields (hidden for msgraph) */}
+      {!isMSGraph && (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>IMAP Server</label>
+            <input
+              type="text"
+              value={form.imap_server || ''}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => update('imap_server', e.target.value)}
+              placeholder="imap.gmail.com:993"
+              className="w-full px-3 py-2 rounded-lg text-xs outline-none"
+              style={inputStyle}
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>SMTP Server</label>
+            <input
+              type="text"
+              value={form.smtp_server || ''}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => update('smtp_server', e.target.value)}
+              placeholder="smtp.gmail.com:587"
+              className="w-full px-3 py-2 rounded-lg text-xs outline-none"
+              style={inputStyle}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Email address + Username (username hidden for msgraph) */}
+      <div className={isMSGraph ? '' : 'grid grid-cols-2 gap-3'}>
         <div>
           <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Email Address</label>
           <input
@@ -262,31 +315,42 @@ function EmailConfigFields({ form, setForm }: EmailConfigFieldsProps) {
             style={inputStyle}
           />
         </div>
+        {!isMSGraph && (
+          <div>
+            <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Username</label>
+            <input
+              type="text"
+              value={form.username || ''}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => update('username', e.target.value)}
+              placeholder="(defaults to address)"
+              className="w-full px-3 py-2 rounded-lg text-xs outline-none"
+              style={inputStyle}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Microsoft Graph credential field */}
+      {isMSGraph && (
         <div>
-          <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Username</label>
+          <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Credential Name</label>
           <input
             type="text"
-            value={form.username || ''}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => update('username', e.target.value)}
-            placeholder="(defaults to address)"
-            className="w-full px-3 py-2 rounded-lg text-xs outline-none"
+            value={form.credential || ''}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => update('credential', e.target.value)}
+            placeholder="email-microsoft"
+            className="w-full px-3 py-2 rounded-lg text-xs outline-none font-mono"
             style={inputStyle}
           />
+          <p className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>
+            Name of the credential (type: oauth_authorization_code) containing your
+            Microsoft 365 refresh token, client ID, and client secret.
+          </p>
         </div>
-      </div>
+      )}
+
+      {/* Behavior settings */}
       <div className="grid grid-cols-3 gap-3">
-        <div>
-          <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Provider</label>
-          <select
-            value={form.provider || 'imap'}
-            onChange={(e: ChangeEvent<HTMLSelectElement>) => update('provider', e.target.value)}
-            className="w-full px-3 py-2 rounded-lg text-xs outline-none"
-            style={inputStyle}
-          >
-            <option value="imap">IMAP</option>
-            <option value="gmail">Gmail</option>
-          </select>
-        </div>
         <div>
           <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Poll Interval (sec)</label>
           <input
@@ -307,18 +371,6 @@ function EmailConfigFields({ form, setForm }: EmailConfigFieldsProps) {
             style={inputStyle}
           />
         </div>
-      </div>
-      <div className="grid grid-cols-2 gap-3">
-        <div className="flex items-center gap-2">
-          <label className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>Mark Read</label>
-          <button
-            onClick={() => update('mark_read', !(form.mark_read ?? true))}
-            className="text-xs"
-            style={{ color: (form.mark_read ?? true) ? '#22c55e' : 'var(--text-muted)' }}
-          >
-            {(form.mark_read ?? true) ? <ToggleRight size={16} /> : <ToggleLeft size={16} />}
-          </button>
-        </div>
         <div>
           <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Max Body Chars</label>
           <input
@@ -329,6 +381,16 @@ function EmailConfigFields({ form, setForm }: EmailConfigFieldsProps) {
             style={inputStyle}
           />
         </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>Mark Read</label>
+        <button
+          onClick={() => update('mark_read', !(form.mark_read ?? true))}
+          className="text-xs"
+          style={{ color: (form.mark_read ?? true) ? '#22c55e' : 'var(--text-muted)' }}
+        >
+          {(form.mark_read ?? true) ? <ToggleRight size={16} /> : <ToggleLeft size={16} />}
+        </button>
       </div>
     </div>
   )

--- a/web/src/components/platformAdmin/ChannelsTab.tsx
+++ b/web/src/components/platformAdmin/ChannelsTab.tsx
@@ -180,7 +180,8 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
             <SlackConfigFields form={form} setForm={setForm} />
           )}
 
-          {/* Secrets */}
+          {/* Secrets (hidden for msgraph which uses credential store) */}
+          {channel.secrets.length > 0 && !(channel.type === 'email' && form.provider === 'msgraph') && (
           <div className="pt-2">
             <label className="block text-xs font-semibold mb-2" style={{ color: 'var(--text-secondary)' }}>Credentials</label>
             <div className="space-y-2">
@@ -202,6 +203,7 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
               ))}
             </div>
           </div>
+          )}
 
           {/* Actions */}
           <div className="flex items-center justify-between pt-3" style={{ borderTop: '1px solid var(--border-color)' }}>

--- a/web/src/components/platformAdmin/ChannelsTab.tsx
+++ b/web/src/components/platformAdmin/ChannelsTab.tsx
@@ -190,7 +190,7 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
               msgraph: [
                 { key: 'channels.email.tenant_id', label: 'Tenant ID' },
                 { key: 'channels.email.client_id', label: 'Client ID' },
-                { key: 'channels.email.client_secret', label: 'Client Secret' },
+                { key: 'channels.email.client_secret', label: 'Client Secret (optional)' },
                 { key: 'channels.email.refresh_token', label: 'Refresh Token' },
               ],
             }

--- a/web/src/components/platformAdmin/ChannelsTab.tsx
+++ b/web/src/components/platformAdmin/ChannelsTab.tsx
@@ -120,7 +120,8 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
     setTesting(true)
     setTestResult(null)
     try {
-      const result = await adminApi.testEmailConnection()
+      // Send current form secrets so test works even before saving
+      const result = await adminApi.testEmailConnection(secrets)
       setTestResult(result)
     } catch (e) {
       setTestResult({ status: 'error', message: (e as Error).message })

--- a/web/src/components/platformAdmin/ChannelsTab.tsx
+++ b/web/src/components/platformAdmin/ChannelsTab.tsx
@@ -211,16 +211,37 @@ function ChannelCard({ channel, expanded, onToggle, onSaved, onError, onDeleted 
                     <div key={s.key}>
                       <label className="block text-xs mb-1" style={{ color: 'var(--text-muted)' }}>
                         {s.label}
-                        {configuredMap[s.key] && <span className="ml-1.5 text-xs" style={{ color: '#22c55e' }}>&#9679;</span>}
+                        {configuredMap[s.key] && secrets[s.key] !== '__CLEAR__' && <span className="ml-1.5 text-xs" style={{ color: '#22c55e' }}>&#9679;</span>}
                       </label>
-                      <input
-                        type="password"
-                        value={secrets[s.key] || ''}
-                        onChange={(e: ChangeEvent<HTMLInputElement>) => setSecrets(prev => ({ ...prev, [s.key]: e.target.value }))}
-                        placeholder={configuredMap[s.key] ? '(set -- leave blank to keep)' : 'Enter value...'}
-                        className="w-full px-3 py-2 rounded-lg text-xs outline-none font-mono"
-                        style={inputStyle}
-                      />
+                      <div className="flex items-center gap-1">
+                        <input
+                          type="password"
+                          value={secrets[s.key] === '__CLEAR__' ? '' : (secrets[s.key] || '')}
+                          onChange={(e: ChangeEvent<HTMLInputElement>) => setSecrets(prev => ({ ...prev, [s.key]: e.target.value }))}
+                          placeholder={configuredMap[s.key] && secrets[s.key] !== '__CLEAR__' ? '(set -- leave blank to keep)' : 'Enter value...'}
+                          className="flex-1 px-3 py-2 rounded-lg text-xs outline-none font-mono"
+                          style={inputStyle}
+                          disabled={secrets[s.key] === '__CLEAR__'}
+                        />
+                        {configuredMap[s.key] && secrets[s.key] !== '__CLEAR__' && (
+                          <button
+                            type="button"
+                            onClick={() => setSecrets(prev => ({ ...prev, [s.key]: '__CLEAR__' }))}
+                            className="px-2 py-2 rounded text-xs"
+                            style={{ color: '#ef4444' }}
+                            title="Clear this secret"
+                          >✕</button>
+                        )}
+                        {secrets[s.key] === '__CLEAR__' && (
+                          <button
+                            type="button"
+                            onClick={() => setSecrets(prev => ({ ...prev, [s.key]: '' }))}
+                            className="px-2 py-2 rounded text-xs"
+                            style={{ color: 'var(--text-muted)' }}
+                            title="Undo clear"
+                          >↩</button>
+                        )}
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/web/src/components/settings/ChannelsSettings.tsx
+++ b/web/src/components/settings/ChannelsSettings.tsx
@@ -65,7 +65,6 @@ export default function ChannelsSettings({ config, onSaved }: { config: Record<s
       address: '',
       username: '',
       password: '',
-      credential: '',
       poll_interval: 30,
       allow_from: [],
       folder: 'INBOX',
@@ -100,7 +99,6 @@ export default function ChannelsSettings({ config, onSaved }: { config: Record<s
           address: em.address || '',
           username: em.username || '',
           password: em.password || '',
-          credential: em.credential || '',
           poll_interval: em.poll_interval || 30,
           allow_from: em.allow_from || [],
           folder: em.folder || 'INBOX',
@@ -222,54 +220,34 @@ export default function ChannelsSettings({ config, onSaved }: { config: Record<s
         onExpand={() => setEmailExpanded(!emailExpanded)}
       >
         <div className="space-y-4">
-          {/* Provider Selection */}
-          <div>
-            <label className="block text-sm font-medium mb-2" style={labelStyle}>
-              Provider
-            </label>
-            <select
-              value={form.email.provider}
-              onChange={(e) => updateEmail({ provider: e.target.value })}
-              className={inputClass}
-              style={inputStyle}
-            >
-              <option value="imap">IMAP/SMTP</option>
-              <option value="gmail">Gmail (IMAP/SMTP)</option>
-              <option value="msgraph">Microsoft 365 (Graph API)</option>
-            </select>
-          </div>
-
-          {/* IMAP/SMTP fields (hidden for msgraph) */}
-          {form.email.provider !== 'msgraph' && (
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium mb-2" style={labelStyle}>
-                  IMAP Server
-                </label>
-                <input
-                  type="text"
-                  value={form.email.imap_server}
-                  onChange={(e) => updateEmail({ imap_server: e.target.value })}
-                  placeholder="imap.gmail.com:993"
-                  className={inputClass + ' font-mono'}
-                  style={inputStyle}
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-2" style={labelStyle}>
-                  SMTP Server
-                </label>
-                <input
-                  type="text"
-                  value={form.email.smtp_server}
-                  onChange={(e) => updateEmail({ smtp_server: e.target.value })}
-                  placeholder="smtp.gmail.com:587"
-                  className={inputClass + ' font-mono'}
-                  style={inputStyle}
-                />
-              </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-2" style={labelStyle}>
+                IMAP Server
+              </label>
+              <input
+                type="text"
+                value={form.email.imap_server}
+                onChange={(e) => updateEmail({ imap_server: e.target.value })}
+                placeholder="imap.gmail.com:993"
+                className={inputClass + ' font-mono'}
+                style={inputStyle}
+              />
             </div>
-          )}
+            <div>
+              <label className="block text-sm font-medium mb-2" style={labelStyle}>
+                SMTP Server
+              </label>
+              <input
+                type="text"
+                value={form.email.smtp_server}
+                onChange={(e) => updateEmail({ smtp_server: e.target.value })}
+                placeholder="smtp.gmail.com:587"
+                className={inputClass + ' font-mono'}
+                style={inputStyle}
+              />
+            </div>
+          </div>
 
           <div>
             <label className="block text-sm font-medium mb-2" style={labelStyle}>
@@ -285,58 +263,34 @@ export default function ChannelsSettings({ config, onSaved }: { config: Record<s
             />
           </div>
 
-          {/* Username/Password fields (hidden for msgraph) */}
-          {form.email.provider !== 'msgraph' && (
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium mb-2" style={labelStyle}>
-                  Username
-                </label>
-                <input
-                  type="text"
-                  value={form.email.username}
-                  onChange={(e) => updateEmail({ username: e.target.value })}
-                  placeholder="Same as email (default)"
-                  className={inputClass}
-                  style={inputStyle}
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-2" style={labelStyle}>
-                  Password
-                </label>
-                <input
-                  type="password"
-                  value={form.email.password}
-                  onChange={(e) => updateEmail({ password: e.target.value })}
-                  placeholder="App password"
-                  className={inputClass}
-                  style={inputStyle}
-                />
-              </div>
-            </div>
-          )}
-
-          {/* Microsoft Graph credential field */}
-          {form.email.provider === 'msgraph' && (
+          <div className="grid grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium mb-2" style={labelStyle}>
-                Credential Name
+                Username
               </label>
               <input
                 type="text"
-                value={form.email.credential}
-                onChange={(e) => updateEmail({ credential: e.target.value })}
-                placeholder="email-microsoft"
-                className={inputClass + ' font-mono'}
+                value={form.email.username}
+                onChange={(e) => updateEmail({ username: e.target.value })}
+                placeholder="Same as email (default)"
+                className={inputClass}
                 style={inputStyle}
               />
-              <p className="text-xs mt-1" style={hintStyle}>
-                Name of the credential (type: oauth_authorization_code) containing your
-                Microsoft 365 refresh token, client ID, and client secret.
-              </p>
             </div>
-          )}
+            <div>
+              <label className="block text-sm font-medium mb-2" style={labelStyle}>
+                Password
+              </label>
+              <input
+                type="password"
+                value={form.email.password}
+                onChange={(e) => updateEmail({ password: e.target.value })}
+                placeholder="App password"
+                className={inputClass}
+                style={inputStyle}
+              />
+            </div>
+          </div>
 
           <div>
             <label className="block text-sm font-medium mb-2" style={labelStyle}>

--- a/web/src/components/settings/ChannelsSettings.tsx
+++ b/web/src/components/settings/ChannelsSettings.tsx
@@ -65,6 +65,7 @@ export default function ChannelsSettings({ config, onSaved }: { config: Record<s
       address: '',
       username: '',
       password: '',
+      credential: '',
       poll_interval: 30,
       allow_from: [],
       folder: 'INBOX',
@@ -99,6 +100,7 @@ export default function ChannelsSettings({ config, onSaved }: { config: Record<s
           address: em.address || '',
           username: em.username || '',
           password: em.password || '',
+          credential: em.credential || '',
           poll_interval: em.poll_interval || 30,
           allow_from: em.allow_from || [],
           folder: em.folder || 'INBOX',
@@ -220,34 +222,54 @@ export default function ChannelsSettings({ config, onSaved }: { config: Record<s
         onExpand={() => setEmailExpanded(!emailExpanded)}
       >
         <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium mb-2" style={labelStyle}>
-                IMAP Server
-              </label>
-              <input
-                type="text"
-                value={form.email.imap_server}
-                onChange={(e) => updateEmail({ imap_server: e.target.value })}
-                placeholder="imap.gmail.com:993"
-                className={inputClass + ' font-mono'}
-                style={inputStyle}
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-2" style={labelStyle}>
-                SMTP Server
-              </label>
-              <input
-                type="text"
-                value={form.email.smtp_server}
-                onChange={(e) => updateEmail({ smtp_server: e.target.value })}
-                placeholder="smtp.gmail.com:587"
-                className={inputClass + ' font-mono'}
-                style={inputStyle}
-              />
-            </div>
+          {/* Provider Selection */}
+          <div>
+            <label className="block text-sm font-medium mb-2" style={labelStyle}>
+              Provider
+            </label>
+            <select
+              value={form.email.provider}
+              onChange={(e) => updateEmail({ provider: e.target.value })}
+              className={inputClass}
+              style={inputStyle}
+            >
+              <option value="imap">IMAP/SMTP</option>
+              <option value="gmail">Gmail (IMAP/SMTP)</option>
+              <option value="msgraph">Microsoft 365 (Graph API)</option>
+            </select>
           </div>
+
+          {/* IMAP/SMTP fields (hidden for msgraph) */}
+          {form.email.provider !== 'msgraph' && (
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-2" style={labelStyle}>
+                  IMAP Server
+                </label>
+                <input
+                  type="text"
+                  value={form.email.imap_server}
+                  onChange={(e) => updateEmail({ imap_server: e.target.value })}
+                  placeholder="imap.gmail.com:993"
+                  className={inputClass + ' font-mono'}
+                  style={inputStyle}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-2" style={labelStyle}>
+                  SMTP Server
+                </label>
+                <input
+                  type="text"
+                  value={form.email.smtp_server}
+                  onChange={(e) => updateEmail({ smtp_server: e.target.value })}
+                  placeholder="smtp.gmail.com:587"
+                  className={inputClass + ' font-mono'}
+                  style={inputStyle}
+                />
+              </div>
+            </div>
+          )}
 
           <div>
             <label className="block text-sm font-medium mb-2" style={labelStyle}>
@@ -263,34 +285,58 @@ export default function ChannelsSettings({ config, onSaved }: { config: Record<s
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          {/* Username/Password fields (hidden for msgraph) */}
+          {form.email.provider !== 'msgraph' && (
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-2" style={labelStyle}>
+                  Username
+                </label>
+                <input
+                  type="text"
+                  value={form.email.username}
+                  onChange={(e) => updateEmail({ username: e.target.value })}
+                  placeholder="Same as email (default)"
+                  className={inputClass}
+                  style={inputStyle}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-2" style={labelStyle}>
+                  Password
+                </label>
+                <input
+                  type="password"
+                  value={form.email.password}
+                  onChange={(e) => updateEmail({ password: e.target.value })}
+                  placeholder="App password"
+                  className={inputClass}
+                  style={inputStyle}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Microsoft Graph credential field */}
+          {form.email.provider === 'msgraph' && (
             <div>
               <label className="block text-sm font-medium mb-2" style={labelStyle}>
-                Username
+                Credential Name
               </label>
               <input
                 type="text"
-                value={form.email.username}
-                onChange={(e) => updateEmail({ username: e.target.value })}
-                placeholder="Same as email (default)"
-                className={inputClass}
+                value={form.email.credential}
+                onChange={(e) => updateEmail({ credential: e.target.value })}
+                placeholder="email-microsoft"
+                className={inputClass + ' font-mono'}
                 style={inputStyle}
               />
+              <p className="text-xs mt-1" style={hintStyle}>
+                Name of the credential (type: oauth_authorization_code) containing your
+                Microsoft 365 refresh token, client ID, and client secret.
+              </p>
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-2" style={labelStyle}>
-                Password
-              </label>
-              <input
-                type="password"
-                value={form.email.password}
-                onChange={(e) => updateEmail({ password: e.target.value })}
-                placeholder="App password"
-                className={inputClass}
-                style={inputStyle}
-              />
-            </div>
-          </div>
+          )}
 
           <div>
             <label className="block text-sm font-medium mb-2" style={labelStyle}>


### PR DESCRIPTION
## Summary

Adds Microsoft Graph API as an email provider for Astonish, replacing IMAP/SMTP for Microsoft 365 mailboxes. Uses delegated OAuth2 permissions with refresh token flow stored as platform secrets.

## Changes

### Backend
- **New `pkg/email/msgraph.go`**: Full Microsoft Graph client implementing `email.Client` interface (ListMessages, ReadMessage, SearchMessages, Send, Reply, MarkRead, MarkUnread, Delete) + `ExchangeMSGraphToken()` helper for OAuth token exchange
- **`pkg/email/msgraph_test.go`**: 8 unit tests with HTTP mocking
- **`pkg/channels/email/email.go`**: Added `TokenFunc` field so the channel adapter works with Graph API polling (not just IMAP)
- **`pkg/daemon/run.go`**: 
  - Email tools (`initEmailTools`) wired for msgraph with token caching
  - Email channel adapter registration handles msgraph provider (inbound polling via Graph API)
  - Token exchange with 5-min cache buffer + refresh token rotation
- **`pkg/api/platform_channels_handlers.go`**:
  - Dynamic secrets based on provider (IMAP: password; msgraph: tenant_id, client_id, client_secret, refresh_token)
  - `client_secret` marked optional (public client apps don't need it)
  - Test Connection handler: exchanges refresh token, calls Graph API `/me`, persists rotated tokens
  - Accepts form secret values so Test Connection works before Save
  - Secret clearing via `__CLEAR__` sentinel
- **`pkg/store/entstore/platform_settings.go`**: Fixed `GetSecret()` to decrypt values (was returning raw encrypted bytes)
- **`pkg/api/platform_admin_handlers.go`**: Exported `GetPlatformSecrets()` for daemon token rotation

### Frontend
- **`web/src/components/platformAdmin/ChannelsTab.tsx`**:
  - Provider dropdown with 'Microsoft 365 (Graph API)' option
  - IMAP/SMTP fields hidden when msgraph selected
  - Secrets section renders correct fields based on current dropdown (not saved state)
  - Test Connection button sends form values (works before save)
  - Clear (✕) button to remove individual secrets
- **`web/src/api/platformAdmin.ts`**: `testEmailConnection()` sends secrets in request body

## Setup Flow
1. Register app in Entra ID with delegated permissions (Mail.ReadWrite, Mail.Send, offline_access, User.Read)
2. Enable 'Allow public client flows' (no client secret needed)
3. One-time Device Code auth to obtain refresh token
4. In Astonish: select Microsoft 365 provider, enter Tenant ID, Client ID, Refresh Token
5. Test Connection to verify
6. Enable and Save

## Bug Fixes (discovered during implementation)
- **`PlatformSecretsStore.GetSecret()`** was returning encrypted bytes instead of decrypting — affected all platform secret reads via the API layer
- **`channel.secrets` null crash** — frontend crashed when backend returned null secrets array