### PR TITLE
feat(app-preview): configurable timeout for useAppAction hook

### DIFF
--- a/pkg/api/app_preview_sandbox.go
+++ b/pkg/api/app_preview_sandbox.go
@@ -235,16 +235,18 @@ const sandboxHTMLBody = `
 
   // ── useAppAction hook ──────────────────────────────────────────────
   // Usage: const runQuery = useAppAction('mcp:server/tool'); const result = await runQuery({ query: '...' })
-  window.useAppAction = function useAppAction(actionId) {
+  // With timeout: const runQuery = useAppAction('mcp:server/tool', { timeout: 300000 }); // 5 min
+  window.useAppAction = function useAppAction(actionId, options) {
+    var actionTimeout = (options && options.timeout) || 30000;
     return React.useCallback(function(payload) {
       return __requestFromParent('action_request', {
         actionId: actionId,
         payload: payload || {}
-      }).then(function(resp) {
+      }, actionTimeout).then(function(resp) {
         if (resp.error) throw new Error(resp.error);
         return resp.data;
       });
-    }, [actionId]);
+    }, [actionId, actionTimeout]);
   };
 
   // ── useAppAI hook ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The `useAppAction` hook in the app preview sandbox now accepts an optional second argument with a `timeout` field (defaults to 30 000 ms).

## Motivation

Some MCP server operations can take significantly longer than the previous hardcoded timeout — for example Docker image builds, large file processing, or complex database migrations. Without a configurable timeout these calls would fail with a timeout error even though the operation is still running successfully on the server side.

This change lets app previews opt into longer timeouts on a per-call basis:

```js
// Default 30s timeout (unchanged behaviour)
const runQuery = useAppAction('mcp:server/tool');

// Explicit 5-minute timeout for slow operations (e.g. Docker builds)
const runBuild = useAppAction('mcp:server/build', { timeout: 300000 });
```

## Changes

- `useAppAction(actionId)" → `useAppAction(actionId, options)`
- Extracts `options.timeout` (default 30 000 ms) and passes it to `__requestFromParent`
- Updates `React.useCallback` dependency array to include the timeout value

## Backwards compatible

Existing callers that pass no second argument get the same 30s default as before — no breaking change.