### PR TITLE
fix(api): load local MCP config in personal mode

### DIFF
--- a/pkg/api/request_helpers.go
+++ b/pkg/api/request_helpers.go
@@ -208,8 +208,12 @@ func loadMCPConfigForRequest(r *http.Request) *config.MCPConfig {
 		return cfg
 	}
 
-	// No platform context — return empty config
-	return &config.MCPConfig{MCPServers: make(map[string]config.MCPServerConfig)}
+	// No platform context (personal mode) — fall back to local mcp_config.json
+	cfg, err := config.LoadMCPConfig()
+	if err != nil || cfg == nil {
+		return &config.MCPConfig{MCPServers: make(map[string]config.MCPServerConfig)}
+	}
+	return cfg
 }
 
 // EffectiveAppConfigFromContext builds the effective application configuration using


### PR DESCRIPTION
## Summary

`loadMCPConfigForRequest` now falls back to loading the local `mcp_config.json` when no platform context (org/team) is present in the request.

## Problem

In personal mode (running Astonish locally without any org/team context), MCP servers configured in the local `mcp_config.json` were silently unavailable. The function returned an empty config with no servers, making all MCP tools unusable through the Studio API.

## Fix

Instead of returning an empty config when there's no platform context, call `config.LoadMCPConfig()` to load the user's local MCP server configuration. If that also fails (file missing, parse error), fall back to the empty config gracefully — same behaviour as before for users with no local config.

## Impact

Users running Astonish in personal/local mode will now have their locally-configured MCP servers available in Studio, just as they would expect from their `mcp_config.json` settings.