### PR TITLE
Fleet setup profiles, drill sandbox fixes, and quiet human-wait behavior

### DIFF
--- a/pkg/api/fleet_recover.go
+++ b/pkg/api/fleet_recover.go
@@ -446,7 +446,10 @@ func determineResumeTarget(lastMsg fleet.Message, fleetCfg *fleet.FleetConfig, s
 
 	routing := fleet.RouteWithLLM(routeCtx, lastMsg, fleetCfg, llm)
 	switch routing.Target {
-	case "customer", "none":
+	case "customer":
+		// Human is the blocker — do not triage incomplete tasks until they reply.
+		return ""
+	case "none":
 		if hasIncompleteTasks {
 			return fleetCfg.GetEntryPoint()
 		}

--- a/pkg/api/fleet_recover_test.go
+++ b/pkg/api/fleet_recover_test.go
@@ -46,15 +46,15 @@ func TestDetermineResumeTarget_WaitingOnCustomerStaysQuiet(t *testing.T) {
 	}
 }
 
-func TestDetermineResumeTarget_WaitingOnCustomerWithIncompleteTasksTriages(t *testing.T) {
+func TestDetermineResumeTarget_WaitingOnCustomerWithIncompleteTasksStaysQuiet(t *testing.T) {
 	cfg := testResumeFleetConfig()
 	got := determineResumeTarget(fleet.Message{
 		Sender:   "po",
 		Text:     "Please review the PR @customer",
 		Mentions: []string{"customer"},
 	}, cfg, &agent.SubAgentManager{}, true)
-	if got != "po" {
-		t.Fatalf("resume = %q, want po for incomplete-task triage", got)
+	if got != "" {
+		t.Fatalf("resume = %q, want empty (customer wait overrides incomplete tasks)", got)
 	}
 }
 

--- a/pkg/fleet/config_test.go
+++ b/pkg/fleet/config_test.go
@@ -1178,6 +1178,31 @@ func TestGitHubMonitor_MarkSeenAndGetState(t *testing.T) {
 	}
 }
 
+func TestGitHubMonitor_MarkSeenPreservesCursor(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	m := NewGitHubMonitor("test-plan", map[string]any{"repo": "owner/repo"}, NewFileMonitorStateStore(stateDir))
+
+	m.MarkSeen(10, "sess-1", "Issue 10")
+	m.UpdateCursor(10, 555)
+	m.IncrementRetryCount(10, "transient")
+
+	m.MarkSeen(10, "sess-2", "Issue 10 updated")
+	s := m.GetIssueState(10)
+	if s == nil {
+		t.Fatal("expected state")
+	}
+	if s.SessionID != "sess-2" {
+		t.Errorf("session_id = %q, want sess-2", s.SessionID)
+	}
+	if s.LastCommentID != 555 {
+		t.Errorf("LastCommentID = %d, want 555 (must not reset)", s.LastCommentID)
+	}
+	if s.RetryCount != 1 {
+		t.Errorf("RetryCount = %d, want 1", s.RetryCount)
+	}
+}
+
 func TestGitHubMonitor_UpdateCursorOnlyAdvances(t *testing.T) {
 	t.Parallel()
 	stateDir := t.TempDir()

--- a/pkg/fleet/github_monitor.go
+++ b/pkg/fleet/github_monitor.go
@@ -354,15 +354,25 @@ func (m *GitHubMonitor) isBackoffExpired(s *SeenIssueState) bool {
 }
 
 // MarkSeen records that an issue has been seen and a session started for it.
-// Called when a new fleet session is created for an issue.
+// Called when a new fleet session is created for an issue. Preserves the
+// comment cursor and retry tracking so poll cycles don't treat old comments
+// as new human replies after a session restart.
 func (m *GitHubMonitor) MarkSeen(issueNumber int, sessionID string, issueTitle string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.state.SeenIssues[issueNumber] = &SeenIssueState{
+	prev := m.state.SeenIssues[issueNumber]
+	next := &SeenIssueState{
 		SessionID:  sessionID,
 		IssueTitle: issueTitle,
 	}
+	if prev != nil {
+		next.LastCommentID = prev.LastCommentID
+		next.RetryCount = prev.RetryCount
+		next.LastFailedAt = prev.LastFailedAt
+		next.LastError = prev.LastError
+	}
+	m.state.SeenIssues[issueNumber] = next
 
 	if err := m.saveStateLocked(); err != nil {
 		slog.Warn("failed to persist state after marking issue seen", "component", "github-monitor", "issue", issueNumber, "error", err)

--- a/pkg/fleet/mailbox_task_test.go
+++ b/pkg/fleet/mailbox_task_test.go
@@ -196,8 +196,8 @@ func TestApplyQuietExitGate_ContinuesWhenOpenTaskClaimable(t *testing.T) {
 		},
 		Headless: true,
 	}
+	// Route "none" exit: ball may be customer but waitingAgent is empty.
 	fs.mu.Lock()
-	fs.waitingAgent = "architect"
 	fs.ballWithCustomer = true
 	fs.mu.Unlock()
 
@@ -214,8 +214,54 @@ func TestApplyQuietExitGate_ContinuesWhenOpenTaskClaimable(t *testing.T) {
 	if fs.ballWithCustomer {
 		t.Fatal("expected ball back with agents after continuing")
 	}
-	if fs.waitingAgent != "" {
-		t.Fatalf("waitingAgent = %q, want empty", fs.waitingAgent)
+}
+
+func TestApplyQuietExitGate_StopsWhenWaitingOnCustomerEvenWithTasks(t *testing.T) {
+	board := &memTaskBoard{}
+	_, err := board.Post(context.Background(), store.FleetTask{
+		SessionID:            "s1",
+		Title:                "Design",
+		RequiredCapabilities: []string{"design.architecture"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := &FleetSession{
+		ID: "s1",
+		FleetConfig: &FleetConfig{
+			Agents: map[string]FleetAgentConfig{
+				"po": {
+					Name:       "PO",
+					TaskPolicy: &AgentTaskPolicy{Claims: []string{"general"}},
+				},
+				"architect": {
+					Name:         "Architect",
+					Capabilities: map[string]bool{"design.architecture": true},
+					TaskPolicy:   &AgentTaskPolicy{Claims: []string{"design.architecture"}},
+				},
+			},
+			Communication: &CommunicationConfig{
+				Flow: []CommunicationNode{{Role: "po", EntryPoint: true, TalksTo: []string{"customer", "architect"}}},
+			},
+			Settings: FleetSettings{TaskBoard: &TaskBoardConfig{ClaimPolicy: "capability_match"}},
+		},
+		Headless: true,
+	}
+	fs.mu.Lock()
+	fs.waitingAgent = "po"
+	fs.ballWithCustomer = true
+	fs.mu.Unlock()
+
+	ctx := store.WithFleetTaskBoardStore(context.Background(), board)
+	next, stop := fs.applyQuietExitGate(ctx, nil, true)
+	if !stop {
+		t.Fatalf("expected hard stop while waiting on customer, next=%v", next)
+	}
+	if len(next) != 0 {
+		t.Fatalf("next = %v, want empty", next)
+	}
+	if state, _ := fs.GetState(); state != StateStopped {
+		t.Fatalf("state = %q, want stopped", state)
 	}
 }
 

--- a/pkg/fleet/session_manager.go
+++ b/pkg/fleet/session_manager.go
@@ -376,9 +376,18 @@ func (fs *FleetSession) Run(ctx context.Context) (runErr error) {
 				}
 				// Idle watchdog fired: the child context timed out but the
 				// parent is still alive. Only continue when incomplete work
-				// remains; otherwise exit quietly (human message or tasks
-				// are the only wake triggers).
+				// remains and we are not waiting on a human; otherwise exit
+				// quietly (human message or tasks are the only wake triggers).
 				if fs.Headless && waitCtx.Err() == context.DeadlineExceeded {
+					fs.mu.RLock()
+					waitingOnCustomer := fs.waitingAgent != ""
+					fs.mu.RUnlock()
+					if waitingOnCustomer {
+						slog.Info("idle watchdog: still waiting on customer, exiting quietly", "component", "fleet", "session_id", fs.ID)
+						fs.notifyBallChange("customer")
+						fs.setState(StateStopped, "")
+						return nil
+					}
 					claimed := fs.claimAndEnqueueTasks(ctx)
 					if len(claimed) > 0 {
 						slog.Info("idle watchdog claimed tasks", "component", "fleet", "session_id", fs.ID, "agents", claimed)
@@ -659,7 +668,9 @@ func (fs *FleetSession) handleRoutingOutcome(ctx context.Context, response Messa
 
 	switch routing.Target {
 	case "customer":
-		fs.deliverMailbox(ctx, response, []string{"customer"})
+		// Deliver to customer and to the sender so a later triage/resume sees
+		// the clarifying question already asked (avoids re-asking the same thing).
+		fs.deliverMailbox(ctx, response, []string{"customer", response.Sender})
 		fs.postExternal(response)
 
 		fs.mu.Lock()
@@ -773,15 +784,29 @@ func (fs *FleetSession) DeliverToMailbox(ctx context.Context, msg Message, recip
 }
 
 // applyQuietExitGate runs claimAndEnqueueTasks before honoring a quiet exit
-// (route customer/none). AI continues only when claimants exist or incomplete
-// tasks remain to triage; otherwise marks the session stopped.
+// (route customer/none). Waiting on a human (waitingAgent set) is a hard stop
+// even if incomplete tasks remain — the human is the blocker. For "none"/other
+// exits, incomplete tasks may still triage via claimants or the entry point.
 func (fs *FleetSession) applyQuietExitGate(ctx context.Context, pending []string, exit bool) (next []string, stop bool) {
+	if !exit {
+		next = append([]string{}, pending...)
+		next = append(next, fs.claimAndEnqueueTasks(ctx)...)
+		return dedupeTargets(next), false
+	}
+
+	fs.mu.RLock()
+	waitingOnCustomer := fs.waitingAgent != ""
+	fs.mu.RUnlock()
+	if waitingOnCustomer {
+		slog.Info("quiet exit: waiting on customer (tasks deferred until human replies)", "component", "fleet", "session_id", fs.ID)
+		fs.notifyBallChange("customer")
+		fs.setState(StateStopped, "")
+		return nil, true
+	}
+
 	next = append([]string{}, pending...)
 	next = append(next, fs.claimAndEnqueueTasks(ctx)...)
 	next = dedupeTargets(next)
-	if !exit {
-		return next, false
-	}
 	if len(next) == 0 && fs.hasIncompleteTasks(ctx) {
 		if ep := fs.FleetConfig.GetEntryPoint(); ep != "" {
 			slog.Info("quiet-exit blocked: incomplete tasks remain, triaging via entry point", "component", "fleet", "session_id", fs.ID, "entry_point", ep)


### PR DESCRIPTION
## Summary
- Adds fleet setup profiles, step-centric wizard, mailbox/task-board orchestration, and credential injection through sandbox session start.
- Hardens drill execution (sandbox browser/localhost, suite credential injection, Results tab/report loading, ContainerIP fallback test).
- Stops fleet agents from spam-following up when waiting on a human: quiet exit without work triggers, and customer-wait overrides incomplete-task triage (fixes issues like juicytrade #75/#77 re-ask loops).
- Improves template UX: default task claims on create, editable agent role keys, and distinct role colors.

## Test plan
- [ ] Create a blank fleet template and confirm save succeeds (default `task_policy.claims`)
- [ ] Rename an agent Role (e.g. `agent` → `po`) and confirm color/key persist
- [ ] Activate a GitHub fleet plan, have PO ask `@customer` a question, confirm no repeat posts until a human replies
- [ ] With open tasks but ball with customer, confirm session stays quiet
- [ ] After a human comment, confirm recovery resumes correctly
- [ ] Run drill suite: browser uses sandbox localhost/`127.0.0.1`, Results tab shows tests/duration
- [ ] `go test ./pkg/fleet/ ./pkg/api/ -run 'TestApplyQuietExitGate|TestDetermineResumeTarget|TestGitHubMonitor_MarkSeen'`
- [ ] `go test ./pkg/drill/ -run 'TestContainerIPFallbackToLocalhost'`

