### PR TITLE
Migrate container images from Docker Hub to GitHub Container Registry (ghcr.io)

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -159,10 +159,10 @@ jobs:
 
             **Docker:**
             ```
-            docker pull schardosin/astonish:beta
-            docker pull schardosin/astonish-incus:beta
-            docker pull schardosin/astonish-sandbox-base:beta
-            docker pull schardosin/astonish-sandbox-openshell:beta
+            docker pull ghcr.io/sap/astonish:beta
+            docker pull ghcr.io/sap/astonish-incus:beta
+            docker pull ghcr.io/sap/astonish-sandbox-base:beta
+            docker pull ghcr.io/sap/astonish-sandbox-openshell:beta
             ```
           files: ./release/*
           draft: false
@@ -177,6 +177,11 @@ jobs:
     name: Docker astonish (beta)
     needs: [prepare, release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -200,31 +205,53 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/sap/astonish
+          tags: |
+            type=raw,value=beta
+            type=raw,value=${{ needs.prepare.outputs.version_tag }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/astonish/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            schardosin/astonish:beta
-            schardosin/astonish:${{ needs.prepare.outputs.version_tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ needs.prepare.outputs.version_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/sap/astonish
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
   docker-incus:
     name: Docker astonish-incus (beta)
     needs: [prepare, release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -265,29 +292,51 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/sap/astonish-incus
+          tags: |
+            type=raw,value=beta
+            type=raw,value=${{ needs.prepare.outputs.version_tag }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/incus/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            schardosin/astonish-incus:beta
-            schardosin/astonish-incus:${{ needs.prepare.outputs.version_tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/sap/astonish-incus
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
   docker-sandbox-base:
     name: Docker sandbox-base (beta)
     needs: [prepare, release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -311,29 +360,51 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/sap/astonish-sandbox-base
+          tags: |
+            type=raw,value=beta
+            type=raw,value=${{ needs.prepare.outputs.version_tag }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/sandbox-base/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            schardosin/astonish-sandbox-base:beta
-            schardosin/astonish-sandbox-base:${{ needs.prepare.outputs.version_tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/sap/astonish-sandbox-base
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
   docker-sandbox-openshell:
     name: Docker sandbox-openshell (beta)
     needs: [prepare, release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -354,21 +425,38 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/sap/astonish-sandbox-openshell
+          tags: |
+            type=raw,value=beta
+            type=raw,value=${{ needs.prepare.outputs.version_tag }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/sandbox-openshell/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: |
-            schardosin/astonish-sandbox-openshell:beta
-            schardosin/astonish-sandbox-openshell:${{ needs.prepare.outputs.version_tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/sap/astonish-sandbox-openshell
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -10,9 +10,6 @@ on:
     types:
       - completed
 
-permissions:
-  contents: read
-
 jobs:
   # --------------------------------------------------------------------------
   # Determine context: dev (manual) vs release (automatic)
@@ -28,10 +25,6 @@ jobs:
     outputs:
       is_release: ${{ steps.ctx.outputs.is_release }}
       version_tag: ${{ steps.ctx.outputs.version_tag }}
-      astonish_tags: ${{ steps.ctx.outputs.astonish_tags }}
-      incus_tags: ${{ steps.ctx.outputs.incus_tags }}
-      sandbox_base_tags: ${{ steps.ctx.outputs.sandbox_base_tags }}
-      sandbox_openshell_tags: ${{ steps.ctx.outputs.sandbox_openshell_tags }}
     steps:
       - name: Determine context
         id: ctx
@@ -42,36 +35,25 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "is_release=false" >> "$GITHUB_OUTPUT"
             echo "version_tag=dev" >> "$GITHUB_OUTPUT"
-            echo "astonish_tags=schardosin/astonish:dev" >> "$GITHUB_OUTPUT"
-            echo "incus_tags=schardosin/astonish-incus:dev" >> "$GITHUB_OUTPUT"
-            echo "sandbox_base_tags=schardosin/astonish-sandbox-base:dev" >> "$GITHUB_OUTPUT"
-            echo "sandbox_openshell_tags=schardosin/astonish-sandbox-openshell:dev" >> "$GITHUB_OUTPUT"
           else
             TAG="$WORKFLOW_HEAD_BRANCH"
             echo "is_release=true" >> "$GITHUB_OUTPUT"
             echo "version_tag=$TAG" >> "$GITHUB_OUTPUT"
-            ASTONISH_TAGS="schardosin/astonish:${TAG}"
-            ASTONISH_TAGS="${ASTONISH_TAGS},schardosin/astonish:latest"
-            echo "astonish_tags=$ASTONISH_TAGS" >> "$GITHUB_OUTPUT"
-            INCUS_TAGS="schardosin/astonish-incus:${TAG}"
-            INCUS_TAGS="${INCUS_TAGS},schardosin/astonish-incus:latest"
-            echo "incus_tags=$INCUS_TAGS" >> "$GITHUB_OUTPUT"
-            SANDBOX_BASE_TAGS="schardosin/astonish-sandbox-base:${TAG}"
-            SANDBOX_BASE_TAGS="${SANDBOX_BASE_TAGS},schardosin/astonish-sandbox-base:latest"
-            echo "sandbox_base_tags=$SANDBOX_BASE_TAGS" >> "$GITHUB_OUTPUT"
-            SANDBOX_OPENSHELL_TAGS="schardosin/astonish-sandbox-openshell:${TAG}"
-            SANDBOX_OPENSHELL_TAGS="${SANDBOX_OPENSHELL_TAGS},schardosin/astonish-sandbox-openshell:latest"
-            echo "sandbox_openshell_tags=$SANDBOX_OPENSHELL_TAGS" >> "$GITHUB_OUTPUT"
           fi
 
   # --------------------------------------------------------------------------
-  # Build and push schardosin/astonish (multi-arch)
+  # Build and push ghcr.io/sap/astonish (multi-arch)
   # Uses the multi-stage Dockerfile which handles cross-compilation internally
   # --------------------------------------------------------------------------
   build-astonish:
     name: Build and push astonish
     runs-on: ubuntu-latest
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -118,33 +100,57 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/sap/astonish
+          tags: |
+            type=raw,value=${{ needs.prepare.outputs.version_tag }}
+            type=raw,value=latest,enable=${{ needs.prepare.outputs.is_release == 'true' }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/astonish/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ needs.prepare.outputs.astonish_tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ needs.prepare.outputs.version_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/sap/astonish
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
   # --------------------------------------------------------------------------
-  # Build and push schardosin/astonish-incus (multi-arch)
+  # Build and push ghcr.io/sap/astonish-incus (multi-arch)
   # Cross-compiles Go binaries on the runner, then builds the Ubuntu-based image
   # --------------------------------------------------------------------------
   build-incus:
     name: Build and push astonish-incus
     runs-on: ubuntu-latest
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -190,25 +196,44 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/sap/astonish-incus
+          tags: |
+            type=raw,value=${{ needs.prepare.outputs.version_tag }}
+            type=raw,value=latest,enable=${{ needs.prepare.outputs.is_release == 'true' }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/incus/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ needs.prepare.outputs.incus_tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/sap/astonish-incus
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
   # --------------------------------------------------------------------------
-  # Build and push schardosin/astonish-sandbox-base (multi-arch)
+  # Build and push ghcr.io/sap/astonish-sandbox-base (multi-arch)
   # Uses the multi-stage docker/sandbox-base/Dockerfile which compiles the
   # entrypoint script generator and astonish binary internally, then produces
   # a minimal Debian-slim runtime image with fuse-overlayfs.
@@ -217,6 +242,11 @@ jobs:
     name: Build and push astonish-sandbox-base
     runs-on: ubuntu-latest
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -242,25 +272,44 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/sap/astonish-sandbox-base
+          tags: |
+            type=raw,value=${{ needs.prepare.outputs.version_tag }}
+            type=raw,value=latest,enable=${{ needs.prepare.outputs.is_release == 'true' }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/sandbox-base/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ needs.prepare.outputs.sandbox_base_tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/sap/astonish-sandbox-base
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
   # --------------------------------------------------------------------------
-  # Build and push schardosin/astonish-sandbox-openshell (amd64 only)
+  # Build and push ghcr.io/sap/astonish-sandbox-openshell (amd64 only)
   # Full-featured sandbox for NVIDIA OpenShell backend: CloakBrowser, KasmVNC,
   # dev tools. Based on ghcr.io/nvidia/openshell-community/sandboxes/base which
   # is amd64-only.
@@ -269,6 +318,11 @@ jobs:
     name: Build and push astonish-sandbox-openshell
     runs-on: ubuntu-latest
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -308,19 +362,38 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Login to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/sap/astonish-sandbox-openshell
+          tags: |
+            type=raw,value=${{ needs.prepare.outputs.version_tag }}
+            type=raw,value=latest,enable=${{ needs.prepare.outputs.is_release == 'true' }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/sandbox-openshell/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ needs.prepare.outputs.sandbox_openshell_tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/sap/astonish-sandbox-openshell
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SHELL := /bin/bash
 BINARY_NAME = astonish
 WEB_DIR = web
 VERSION ?= dev
-DOCKER_REGISTRY ?= schardosin
+DOCKER_REGISTRY ?= ghcr.io/sap
 DEV_TAG ?= dev
 
 # Default target
@@ -631,8 +631,8 @@ helm-deps:
 # Requires: astonish-linux-amd64 binary to exist (run build-linux first)
 docker-incus: build-linux
 	@echo "Building Incus Docker image..."
-	docker build -f docker/incus/Dockerfile -t schardosin/astonish-incus:$(VERSION) .
-	@echo "Image built: schardosin/astonish-incus:$(VERSION)"
+	docker build -f docker/incus/Dockerfile -t ghcr.io/sap/astonish-incus:$(VERSION) .
+	@echo "Image built: ghcr.io/sap/astonish-incus:$(VERSION)"
 
 # Build the OpenShell sandbox image (NVIDIA sandbox base + Astonish agent tools)
 docker-sandbox-openshell: build-linux

--- a/deploy/helm/astonish/values-dev-proxmox.yaml
+++ b/deploy/helm/astonish/values-dev-proxmox.yaml
@@ -20,7 +20,7 @@
 # Control-plane image
 # ------------------------------------------------------------------
 image:
-  repository: schardosin/astonish
+  repository: ghcr.io/sap/astonish
   tag: dev
   pullPolicy: Always
 
@@ -76,7 +76,7 @@ sandbox:
     fuseDeviceResource: ""     # No device plugin on dev; mknod path.
 
   image:
-    repository: schardosin/astonish-sandbox-base
+    repository: ghcr.io/sap/astonish-sandbox-base
     tag: dev
     pullPolicy: IfNotPresent
 

--- a/deploy/helm/astonish/values-e2e-openshell.yaml
+++ b/deploy/helm/astonish/values-e2e-openshell.yaml
@@ -27,7 +27,7 @@
 # Control-plane image (unused — pods stay at replicas: 0).
 # ------------------------------------------------------------------
 image:
-  repository: schardosin/astonish
+  repository: ghcr.io/sap/astonish
   tag: dev
   pullPolicy: IfNotPresent
 
@@ -79,7 +79,7 @@ sandbox:
     gateway:
       addr: ""  # auto-derived: astonishe2eos-openshell.astonishe2eos.svc.cluster.local:8080
     image:
-      repository: schardosin/astonish-sandbox-openshell
+      repository: ghcr.io/sap/astonish-sandbox-openshell
       tag: dev
     registry:
       url: ""
@@ -99,7 +99,7 @@ sandbox:
 
   # Image settings (K8s-specific, but chart renders them).
   image:
-    repository: schardosin/astonish-sandbox-base
+    repository: ghcr.io/sap/astonish-sandbox-base
     tag: dev
     pullPolicy: IfNotPresent
 
@@ -141,7 +141,7 @@ openshell:
   server:
     disableTls: true
     sandboxNamespace: "astonishe2eos-sandbox"
-    sandboxImage: "schardosin/astonish-sandbox-openshell:dev"
+    sandboxImage: "ghcr.io/sap/astonish-sandbox-openshell:dev"
     auth:
       allowUnauthenticatedUsers: true
     tls:

--- a/deploy/helm/astonish/values-e2e.yaml
+++ b/deploy/helm/astonish/values-e2e.yaml
@@ -32,7 +32,7 @@
 # Kept consistent with dev so the chart renders cleanly.
 # ------------------------------------------------------------------
 image:
-  repository: schardosin/astonish
+  repository: ghcr.io/sap/astonish
   tag: dev
   pullPolicy: IfNotPresent
 
@@ -95,7 +95,7 @@ sandbox:
     fuseDeviceResource: ""
 
   image:
-    repository: schardosin/astonish-sandbox-base
+    repository: ghcr.io/sap/astonish-sandbox-base
     tag: dev
     pullPolicy: IfNotPresent
 

--- a/deploy/helm/astonish/values.yaml
+++ b/deploy/helm/astonish/values.yaml
@@ -4,7 +4,7 @@
 
 # -- Container image settings (control plane: api + worker)
 image:
-  repository: schardosin/astonish
+  repository: ghcr.io/sap/astonish
   tag: dev
   pullPolicy: Always
 
@@ -181,7 +181,7 @@ sandbox:
   # Sandbox base image — MUST ship the Phase F overlay entrypoint
   # (see docker/sandbox-base/Dockerfile).
   image:
-    repository: schardosin/astonish-sandbox-base
+    repository: ghcr.io/sap/astonish-sandbox-base
     tag: dev
     pullPolicy: IfNotPresent
 
@@ -245,7 +245,7 @@ sandbox:
 
     # Sandbox container image (Astonish agent tooling + OpenShell supervisor).
     image:
-      repository: schardosin/astonish-sandbox-openshell
+      repository: ghcr.io/sap/astonish-sandbox-openshell
       tag: dev
 
     # Container image registry for custom-built sandbox images.
@@ -253,7 +253,7 @@ sandbox:
     registry:
       # OCI registry URL prefix. Images are pushed as:
       #   <url>/astonish-sandbox-<scope>:<content-hash>
-      # Examples: "docker.io/schardosin", "ghcr.io/schardosin", "harbor.internal:5000/astonish"
+      # Examples: "ghcr.io/sap", "ghcr.io/org", "harbor.internal:5000/astonish"
       url: ""
       # Name of the K8s Secret (type kubernetes.io/dockerconfigjson) used by Kaniko.
       # If username/password are provided below, the chart creates this secret automatically.
@@ -417,7 +417,7 @@ openshell:
     sandboxNamespace: "astonish-sandbox"
     # Default sandbox image — Astonish agent tooling.
     # Must match sandbox.openshell.image.repository:tag above.
-    sandboxImage: "schardosin/astonish-sandbox-openshell:dev"
+    sandboxImage: "ghcr.io/sap/astonish-sandbox-openshell:dev"
     # Always pull sandbox image so :dev tag updates are picked up immediately.
     sandboxImagePullPolicy: "Always"
     auth:

--- a/docker/incus/Dockerfile
+++ b/docker/incus/Dockerfile
@@ -6,14 +6,14 @@
 #
 # Build (single-arch, local dev):
 #   GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o astonish-linux-amd64 .
-#   docker build -f docker/incus/Dockerfile -t schardosin/astonish-incus:dev .
+#   docker build -f docker/incus/Dockerfile -t ghcr.io/sap/astonish-incus:dev .
 #
 # Build (multi-arch, CI):
 #   # Pre-build both binaries, then:
 #   docker buildx build --platform linux/amd64,linux/arm64 \
-#     -f docker/incus/Dockerfile -t schardosin/astonish-incus:v1.2.3 --push .
+#     -f docker/incus/Dockerfile -t ghcr.io/sap/astonish-incus:v1.2.3 --push .
 #
-# The image is published to Docker Hub by the docker-incus GitHub Action.
+# The image is published to ghcr.io by the docker-images GitHub Action.
 # Users never build this image — astonish pulls it automatically.
 
 FROM ubuntu:24.04

--- a/docker/sandbox-base/Dockerfile
+++ b/docker/sandbox-base/Dockerfile
@@ -47,7 +47,7 @@
 #     layer plus org-wide and template-specific layers on CephFS).
 #
 # Build:
-#   docker build -f docker/sandbox-base/Dockerfile -t schardosin/astonish-sandbox-base:latest .
+#   docker build -f docker/sandbox-base/Dockerfile -t ghcr.io/sap/astonish-sandbox-base:latest .
 #
 # Publish:
 #   The image tag MUST match SandboxKubernetesConfig.SandboxImage's

--- a/docker/sandbox-openshell/Dockerfile
+++ b/docker/sandbox-openshell/Dockerfile
@@ -23,7 +23,7 @@
 #
 # Configure in OpenShell gateway values:
 #   server:
-#     sandboxImage: schardosin/astonish-sandbox-openshell:latest
+#     sandboxImage: ghcr.io/sap/astonish-sandbox-openshell:latest
 
 FROM ghcr.io/nvidia/openshell-community/sandboxes/base:latest
 

--- a/docs/architecture/openshell-sandbox-backend.md
+++ b/docs/architecture/openshell-sandbox-backend.md
@@ -494,7 +494,7 @@ sandbox:
   openshell:
     enabled: true
     image:
-      repository: schardosin/astonish-sandbox-openshell
+      repository: ghcr.io/sap/astonish-sandbox-openshell
       tag: dev
 
 # OpenShell subchart pass-through
@@ -502,7 +502,7 @@ openshell:
   server:
     disableTls: true  # Mesh handles encryption
     sandboxNamespace: "astonishdev-sandbox"
-    sandboxImage: "schardosin/astonish-sandbox-openshell:dev"
+    sandboxImage: "ghcr.io/sap/astonish-sandbox-openshell:dev"
 ```
 
 ### Go Config Struct

--- a/docs/architecture/sandbox-backends.md
+++ b/docs/architecture/sandbox-backends.md
@@ -939,7 +939,7 @@ sandbox:
     create: true                # creates Role + RoleBinding in sandbox ns
 
   image:
-    repository: schardosin/astonish-sandbox-base
+    repository: ghcr.io/sap/astonish-sandbox-base
     tag: dev                    # mutable tag → backend auto-uses Always
     pullPolicy: IfNotPresent    # used for runtime pods; seed Job overrides
 
@@ -1341,7 +1341,7 @@ The prebuilt `astonish-sandbox-base` image MUST ship GNU tar with xattr/ACL supp
 ### Astonish ships
 
 - Helm chart at `deploy/helm/astonish` with templates for the sandbox namespace, RBAC, RWX PVCs, base-layer seed Job, and an optional FUSE device plugin DaemonSet — all driven by one per-environment values file (see `deploy/helm/astonish/values-dev-proxmox.yaml` for a complete example).
-- Prebuilt base sandbox image: `schardosin/astonish-sandbox-base:<version>` (Docker Hub). Phase F: image bundles `fuse-overlayfs` and the overlay-mode dispatcher in the entrypoint.
+- Prebuilt base sandbox image: `ghcr.io/sap/astonish-sandbox-base:<version>` (GitHub Container Registry). Phase F: image bundles `fuse-overlayfs` and the overlay-mode dispatcher in the entrypoint.
 - ConfigMap/Secret templates for backend configuration.
 - Pre-rendered ServiceAccount + Role bindings for the API/Worker to manage the sandbox namespace.
 

--- a/docs/testing-docker-incus.md
+++ b/docs/testing-docker-incus.md
@@ -59,7 +59,7 @@ This creates `astonish-linux-amd64` in the project root.
 
 ```bash
 # Build the Incus Docker image (uses docker/incus/Dockerfile)
-docker build -f docker/incus/Dockerfile -t schardosin/astonish-incus:latest .
+docker build -f docker/incus/Dockerfile -t ghcr.io/sap/astonish-incus:latest .
 ```
 
 This builds the image with:
@@ -84,7 +84,7 @@ go build -o astonish .
 ```bash
 # This will:
 # 1. Detect Docker (PlatformDockerIncus)
-# 2. Use the locally-built schardosin/astonish-incus:latest image (no pull needed)
+# 2. Use the locally-built ghcr.io/sap/astonish-incus:latest image (no pull needed)
 # 3. Create the astonish-incus container with privileged mode
 # 4. Wait for Incus API on localhost:8443
 # 5. Initialize the @base template inside Incus
@@ -94,7 +94,7 @@ go build -o astonish .
 Expected output:
 ```
 Setting up Docker+Incus runtime...
-[sandbox] Pulling Docker image schardosin/astonish-incus:latest...
+[sandbox] Pulling Docker image ghcr.io/sap/astonish-incus:latest...
 [sandbox] Creating Docker container astonish-incus...
 [sandbox] Docker container astonish-incus created, waiting for Incus API...
 Docker+Incus runtime ready.
@@ -200,7 +200,7 @@ apt-get update && apt-get install -y docker.io
 
 # Build and test
 make build-linux
-docker build -f docker/incus/Dockerfile -t schardosin/astonish-incus:latest .
+docker build -f docker/incus/Dockerfile -t ghcr.io/sap/astonish-incus:latest .
 go build -o astonish .
 ./astonish sandbox status
 ```
@@ -221,13 +221,13 @@ To inspect what's inside the built image:
 
 ```bash
 # Check the astonish binary is present and executable
-docker run --rm schardosin/astonish-incus:latest /usr/local/bin/astonish --version
+docker run --rm ghcr.io/sap/astonish-incus:latest /usr/local/bin/astonish --version
 
 # Check Incus is installed
-docker run --rm schardosin/astonish-incus:latest incus --version
+docker run --rm ghcr.io/sap/astonish-incus:latest incus --version
 
 # Check the entrypoint script
-docker run --rm schardosin/astonish-incus:latest cat /usr/local/bin/entrypoint-incus.sh
+docker run --rm ghcr.io/sap/astonish-incus:latest cat /usr/local/bin/entrypoint-incus.sh
 ```
 
 ## 5. Troubleshooting
@@ -237,7 +237,7 @@ docker run --rm schardosin/astonish-incus:latest cat /usr/local/bin/entrypoint-i
 The image needs to exist locally. Build it with:
 ```bash
 make build-linux
-docker build -f docker/incus/Dockerfile -t schardosin/astonish-incus:latest .
+docker build -f docker/incus/Dockerfile -t ghcr.io/sap/astonish-incus:latest .
 ```
 
 ### "Incus API not reachable" timeout
@@ -274,7 +274,7 @@ docker exec astonish-incus ls /var/lib/incus/storage-pools/default/containers-sn
 docker stop astonish-incus
 docker rm astonish-incus
 docker volume rm astonish-incus-data
-docker rmi schardosin/astonish-incus:latest
+docker rmi ghcr.io/sap/astonish-incus:latest
 ```
 
 Then re-run `./astonish sandbox init` to start fresh.

--- a/docs/website/docs/configuration/config-reference.md
+++ b/docs/website/docs/configuration/config-reference.md
@@ -205,14 +205,14 @@ sandbox:
     idle_timeout_minutes: 10
   kubernetes:                  # Only for backend: k8s
     namespace: "astonish-sandboxes"
-    sandbox_image: "schardosin/astonish-sandbox-base:latest"
+    sandbox_image: "ghcr.io/sap/astonish-sandbox-base:latest"
     overlay_mode: "fuse"       # fuse | kernel | auto
     layers_pvc_name: "astonish-layers"
     uppers_pvc_name: "astonish-uppers"
   openshell:                   # Only for backend: openshell
     gateway_addr: ""
     gateway_tls: true
-    sandbox_image: "schardosin/astonish-sandbox-openshell:latest"
+    sandbox_image: "ghcr.io/sap/astonish-sandbox-openshell:latest"
     network_policy:
       presets: ["default"]
       extra_endpoints: []
@@ -251,7 +251,7 @@ sandbox:
     processes: 500
   kubernetes:
     namespace: "astonish-sandbox"
-    sandbox_image: "schardosin/astonish-sandbox-base:latest"
+    sandbox_image: "ghcr.io/sap/astonish-sandbox-base:latest"
     overlay_mode: "fuse"
 ```
 

--- a/docs/website/docs/deployment/kubernetes.md
+++ b/docs/website/docs/deployment/kubernetes.md
@@ -99,7 +99,7 @@ Create a `values.yaml` file:
 
 ```yaml
 image:
-  repository: schardosin/astonish
+  repository: ghcr.io/sap/astonish
   tag: "latest"
   pullPolicy: IfNotPresent
 
@@ -138,7 +138,7 @@ sandbox:
   enabled: true
   backend: k8s
   image:
-    repository: schardosin/astonish-sandbox-base
+    repository: ghcr.io/sap/astonish-sandbox-base
     tag: "latest"
   storage:
     storageClassName: "<your-rwx-storage-class>"

--- a/docs/website/docs/deployment/openshell.md
+++ b/docs/website/docs/deployment/openshell.md
@@ -143,7 +143,7 @@ When your cluster has Istio, the mesh handles encryption between the control pla
 # Control-plane image
 # ------------------------------------------------------------------
 image:
-  repository: schardosin/astonish
+  repository: ghcr.io/sap/astonish
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -207,7 +207,7 @@ sandbox:
       addr: ""
     # Sandbox container image (Astonish agent tooling + OpenShell supervisor)
     image:
-      repository: schardosin/astonish-sandbox-openshell
+      repository: ghcr.io/sap/astonish-sandbox-openshell
       tag: latest
     # Network egress policy for sandboxes
     # Available presets: "default", "code_hosting", "package_registries",
@@ -251,7 +251,7 @@ openshell:
     # Must match the computed sandbox namespace
     sandboxNamespace: "astonish-sandbox"
     # Must match sandbox.openshell.image above
-    sandboxImage: "schardosin/astonish-sandbox-openshell:latest"
+    sandboxImage: "ghcr.io/sap/astonish-sandbox-openshell:latest"
     auth:
       # Istio AuthorizationPolicy handles identity
       allowUnauthenticatedUsers: true
@@ -287,7 +287,7 @@ openshell:
     # Gateway terminates mTLS itself
     disableTls: false
     sandboxNamespace: "astonish-sandbox"
-    sandboxImage: "schardosin/astonish-sandbox-openshell:latest"
+    sandboxImage: "ghcr.io/sap/astonish-sandbox-openshell:latest"
     auth:
       # Without mesh identity, consider restricting access
       allowUnauthenticatedUsers: false

--- a/pkg/api/platform_configure_base.go
+++ b/pkg/api/platform_configure_base.go
@@ -347,7 +347,7 @@ func PlatformBaseConfigOptionalToolsHandler(w http.ResponseWriter, r *http.Reque
 // Sets or clears the custom sandbox image on the @base template. This is the
 // platform-wide image override used by the OpenShell backend.
 //
-// Request body: {"image": "ghcr.io/schardosin/custom-sandbox:v2"} or {"image": ""} to clear.
+// Request body: {"image": "ghcr.io/sap/custom-sandbox:v2"} or {"image": ""} to clear.
 func PlatformBaseImageHandler(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Image string `json:"image"`

--- a/pkg/api/sandbox_backend_test.go
+++ b/pkg/api/sandbox_backend_test.go
@@ -230,7 +230,7 @@ func slicesEqual(a, b []string) bool {
 
 func TestResolveTemplateImageWith_CustomImage(t *testing.T) {
 	ts := newMockTemplateStore()
-	img := "docker.io/schardosin/astonish-sandbox-general:5de96c7a79eb"
+	img := "ghcr.io/sap/astonish-sandbox-general:5de96c7a79eb"
 	ts.templates["tpl-img-1"] = &store.SandboxTemplate{
 		ID:           "tpl-img-1",
 		Slug:         "team-general",

--- a/pkg/api/team_template_handlers.go
+++ b/pkg/api/team_template_handlers.go
@@ -734,7 +734,7 @@ func itoa(n int) string {
 // instead of the global default. This bypasses the interactive editor/snapshot
 // flow — teams build their own image with packages pre-installed.
 //
-// Request body: {"image": "ghcr.io/schardosin/custom-sandbox:v2"} or {"image": ""} to clear.
+// Request body: {"image": "ghcr.io/sap/custom-sandbox:v2"} or {"image": ""} to clear.
 // Response: {"status": "ok", "image": "<image>"}
 func TeamTemplateImageHandler(w http.ResponseWriter, r *http.Request) {
 	if !RequireTeamAdmin(w, r) {

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -102,7 +102,7 @@ type SandboxOpenShellConfig struct {
 	// SandboxImage is the container image for sandbox pods. This image
 	// should contain Astonish agent tooling. The OpenShell supervisor is
 	// sideloaded by the gateway automatically.
-	// Default: "schardosin/astonish-sandbox-openshell:latest".
+	// Default: "ghcr.io/sap/astonish-sandbox-openshell:latest".
 	SandboxImage string `yaml:"sandbox_image,omitempty" json:"sandbox_image,omitempty"`
 
 	// Registry configures the OCI registry for custom-built sandbox images.
@@ -137,7 +137,7 @@ type SandboxOpenShellConfig struct {
 type RegistryConfig struct {
 	// URL is the registry URL prefix. Images are pushed as:
 	//   <URL>/astonish-sandbox-<scope>:<content-hash>
-	// Examples: "docker.io/schardosin", "ghcr.io/org", "harbor.local:5000/proj"
+	// Examples: "ghcr.io/sap", "ghcr.io/org", "harbor.local:5000/proj"
 	URL string `yaml:"url,omitempty" json:"url,omitempty"`
 
 	// SecretName is the name of a K8s Secret (type kubernetes.io/dockerconfigjson)
@@ -262,7 +262,7 @@ type SandboxKubernetesConfig struct {
 
 	// SandboxImage is the container image for sandbox pods. Must ship
 	// the overlay entrypoint and the astonish node binary. Default:
-	// "schardosin/astonish-sandbox-base:latest".
+	// "ghcr.io/sap/astonish-sandbox-base:latest".
 	SandboxImage string `yaml:"sandbox_image,omitempty" json:"sandbox_image,omitempty"`
 
 	// LayersPVCName / UppersPVCName name the RWX PVCs backing the

--- a/pkg/sandbox/imagebuilder/imagebuilder.go
+++ b/pkg/sandbox/imagebuilder/imagebuilder.go
@@ -24,7 +24,7 @@ type Config struct {
 	Namespace string
 
 	// RegistryURL is the OCI registry prefix for pushing images.
-	// Example: "docker.io/schardosin", "ghcr.io/org"
+	// Example: "ghcr.io/sap", "ghcr.io/org"
 	RegistryURL string
 
 	// SecretName is the K8s Secret (dockerconfigjson) with registry creds.

--- a/pkg/sandbox/imagebuilder/imagebuilder_test.go
+++ b/pkg/sandbox/imagebuilder/imagebuilder_test.go
@@ -15,11 +15,11 @@ func TestGenerateDockerfile(t *testing.T) {
 	}{
 		{
 			name:         "platform only",
-			baseImage:    "schardosin/astonish-sandbox-openshell:dev",
+			baseImage:    "ghcr.io/sap/astonish-sandbox-openshell:dev",
 			platformBody: "USER root\nRUN apt-get update && apt-get install -y curl\nUSER sandbox",
 			teamBody:     "",
 			wantLines: []string{
-				"FROM schardosin/astonish-sandbox-openshell:dev",
+				"FROM ghcr.io/sap/astonish-sandbox-openshell:dev",
 				"# --- Platform recipe ---",
 				"USER root",
 				"RUN apt-get update && apt-get install -y curl",
@@ -117,11 +117,11 @@ func TestImageRef(t *testing.T) {
 		wantPrefix   string
 	}{
 		{
-			name:         "docker hub base",
-			registryURL:  "docker.io/schardosin",
+			name:         "ghcr base",
+			registryURL:  "ghcr.io/sap",
 			scope:        "base",
 			combinedBody: CombinedBody("RUN apt-get install -y curl git", ""),
-			wantPrefix:   "docker.io/schardosin/astonish-sandbox-base:",
+			wantPrefix:   "ghcr.io/sap/astonish-sandbox-base:",
 		},
 		{
 			name:         "ghcr team",

--- a/pkg/sandbox/incus/docker.go
+++ b/pkg/sandbox/incus/docker.go
@@ -20,8 +20,8 @@ const (
 	// This volume survives container recreation (upgrades).
 	DockerVolumeName = "astonish-incus-data"
 
-	// DockerImageRepo is the Docker Hub repository for the Incus runtime image.
-	DockerImageRepo = "schardosin/astonish-incus"
+	// DockerImageRepo is the container registry repository for the Incus runtime image.
+	DockerImageRepo = "ghcr.io/sap/astonish-incus"
 
 	// DockerVersionLabel is the container label storing the astonish version
 	// that created/upgraded the container. Used for auto-upgrade detection.
@@ -80,7 +80,7 @@ func pullOrFallback(imageTag string) error {
 		return fmt.Errorf("Docker image %s not found (pull failed: %s).\n"+
 			"For dev testing, build it locally:\n"+
 			"  make docker-incus\n"+
-			"  docker tag schardosin/astonish-incus:dev schardosin/astonish-incus:latest",
+			"  docker tag ghcr.io/sap/astonish-incus:dev ghcr.io/sap/astonish-incus:latest",
 			imageTag, firstLine(output))
 	}
 	return nil

--- a/pkg/sandbox/k8s/backend.go
+++ b/pkg/sandbox/k8s/backend.go
@@ -164,7 +164,7 @@ type Config struct {
 	// SandboxImage is the container image used for sandbox pods. It
 	// MUST ship the astonish-sandbox-entrypoint binary and the node
 	// runtime. Defaults to
-	// "schardosin/astonish-sandbox-base:latest" (§10 "Astonish ships").
+	// "ghcr.io/sap/astonish-sandbox-base:latest" (§10 "Astonish ships").
 	SandboxImage string
 
 	// MaxChainDepth caps the overlayfs lowerdir chain (default 20).
@@ -249,7 +249,7 @@ func (c *Config) applyDefaults() {
 		c.UppersPVCName = "astonish-uppers"
 	}
 	if c.SandboxImage == "" {
-		c.SandboxImage = "schardosin/astonish-sandbox-base:latest"
+		c.SandboxImage = "ghcr.io/sap/astonish-sandbox-base:latest"
 	}
 	if c.MaxChainDepth <= 0 {
 		c.MaxChainDepth = 20

--- a/pkg/sandbox/k8s/image_test.go
+++ b/pkg/sandbox/k8s/image_test.go
@@ -15,12 +15,12 @@ func TestImagePullPolicy(t *testing.T) {
 		// Mutable tags → Always.
 		{
 			name:   "dev tag",
-			image:  "schardosin/astonish-sandbox-base:dev",
+			image:  "ghcr.io/sap/astonish-sandbox-base:dev",
 			expect: corev1.PullAlways,
 		},
 		{
 			name:   "latest tag",
-			image:  "docker.io/schardosin/astonish-sandbox-base:latest",
+			image:  "ghcr.io/sap/astonish-sandbox-base:latest",
 			expect: corev1.PullAlways,
 		},
 		{
@@ -35,36 +35,36 @@ func TestImagePullPolicy(t *testing.T) {
 		},
 		{
 			name:   "no tag implies latest",
-			image:  "schardosin/astonish-sandbox-base",
+			image:  "ghcr.io/sap/astonish-sandbox-base",
 			expect: corev1.PullAlways,
 		},
 
 		// Immutable tags → IfNotPresent.
 		{
 			name:   "semver tag",
-			image:  "schardosin/astonish-sandbox-base:v1.2.3",
+			image:  "ghcr.io/sap/astonish-sandbox-base:v1.2.3",
 			expect: corev1.PullIfNotPresent,
 		},
 		{
 			name:   "sha tag",
-			image:  "schardosin/astonish-sandbox-base:abc1234",
+			image:  "ghcr.io/sap/astonish-sandbox-base:abc1234",
 			expect: corev1.PullIfNotPresent,
 		},
 		{
 			name:   "release tag",
-			image:  "docker.io/schardosin/astonish-sandbox-base:2.9.0",
+			image:  "ghcr.io/sap/astonish-sandbox-base:2.9.0",
 			expect: corev1.PullIfNotPresent,
 		},
 
 		// Digest-pinned → IfNotPresent.
 		{
 			name:   "digest pinned with tag",
-			image:  "schardosin/astonish-sandbox-base:dev@sha256:72740bb3e30ac977838be51d5f43f08d934f9fe89432493797eb64cb3113caf7",
+			image:  "ghcr.io/sap/astonish-sandbox-base:dev@sha256:72740bb3e30ac977838be51d5f43f08d934f9fe89432493797eb64cb3113caf7",
 			expect: corev1.PullIfNotPresent,
 		},
 		{
 			name:   "digest pinned without tag",
-			image:  "schardosin/astonish-sandbox-base@sha256:72740bb3e30ac977838be51d5f43f08d934f9fe89432493797eb64cb3113caf7",
+			image:  "ghcr.io/sap/astonish-sandbox-base@sha256:72740bb3e30ac977838be51d5f43f08d934f9fe89432493797eb64cb3113caf7",
 			expect: corev1.PullIfNotPresent,
 		},
 

--- a/pkg/sandbox/node_tool_test.go
+++ b/pkg/sandbox/node_tool_test.go
@@ -162,7 +162,7 @@ func TestGetClientFromContext_ImageOnly(t *testing.T) {
 	nt := &NodeTool{pool: spy}
 
 	ctx := context.Background()
-	ctx = store.WithSandboxImage(ctx, "ghcr.io/schardosin/custom-sandbox:v2")
+	ctx = store.WithSandboxImage(ctx, "ghcr.io/sap/custom-sandbox:v2")
 
 	client := nt.getClientFromContext(ctx, "session-img")
 	if client == nil {
@@ -171,7 +171,7 @@ func TestGetClientFromContext_ImageOnly(t *testing.T) {
 	if spy.method != "GetOrCreateWithImage" {
 		t.Fatalf("expected GetOrCreateWithImage, got %s", spy.method)
 	}
-	if spy.image != "ghcr.io/schardosin/custom-sandbox:v2" {
+	if spy.image != "ghcr.io/sap/custom-sandbox:v2" {
 		t.Fatalf("expected custom image, got %q", spy.image)
 	}
 	if len(spy.chain) != 0 {

--- a/pkg/sandbox/openshell/backend.go
+++ b/pkg/sandbox/openshell/backend.go
@@ -55,7 +55,7 @@ type Config struct {
 	AuthToken string
 
 	// SandboxImage is the container image for OpenShell sandbox pods.
-	// Default: "schardosin/astonish-sandbox-openshell:latest"
+	// Default: "ghcr.io/sap/astonish-sandbox-openshell:latest"
 	SandboxImage string
 
 	// AppConfig stores the full OpenShell config from app_config.yaml.
@@ -67,7 +67,7 @@ func (c *Config) applyDefaults() {
 		c.GatewayAddr = "openshell.openshell.svc.cluster.local:8080"
 	}
 	if c.SandboxImage == "" {
-		c.SandboxImage = "schardosin/astonish-sandbox-openshell:latest"
+		c.SandboxImage = "ghcr.io/sap/astonish-sandbox-openshell:latest"
 	}
 }
 

--- a/tests/e2eboot/bootstrap.go
+++ b/tests/e2eboot/bootstrap.go
@@ -338,7 +338,7 @@ func writeConfig(t *testing.T, dir, platformDSN, suffix string) {
   openshell:
     gateway_addr: %s
     gateway_tls: false
-    sandbox_image: schardosin/astonish-sandbox-openshell:dev
+    sandbox_image: ghcr.io/sap/astonish-sandbox-openshell:dev
     network_policy:
       presets:
         - default
@@ -372,7 +372,7 @@ func writeConfig(t *testing.T, dir, platformDSN, suffix string) {
     control_plane_namespace: %s
     overlay_mode: fuse
     privileged_pods: true
-    sandbox_image: schardosin/astonish-sandbox-base:dev
+    sandbox_image: ghcr.io/sap/astonish-sandbox-base:dev
     layers_pvc_name: astonish-layers
     uppers_pvc_name: astonish-uppers
 `, kubeconfigPath, sandboxNS, controlPlaneNS)

--- a/tests/e2eboot/bootstrap_sqlite.go
+++ b/tests/e2eboot/bootstrap_sqlite.go
@@ -190,7 +190,7 @@ sandbox:
     control_plane_namespace: %s
     overlay_mode: fuse
     privileged_pods: true
-    sandbox_image: schardosin/astonish-sandbox-base:dev
+    sandbox_image: ghcr.io/sap/astonish-sandbox-base:dev
     layers_pvc_name: astonish-layers
     uppers_pvc_name: astonish-uppers
 `, bifrostURL, dataDir, defaultJWTSecret, kubeconfigPath, sandboxNS, controlPlaneNS)

--- a/tests/e2eboot/platform_core.go
+++ b/tests/e2eboot/platform_core.go
@@ -372,7 +372,7 @@ func writeConfigFile(dir, platformDSN, suffix, bifrostURL, jwtSecret string) err
   openshell:
     gateway_addr: %s
     gateway_tls: false
-    sandbox_image: schardosin/astonish-sandbox-openshell:dev
+    sandbox_image: ghcr.io/sap/astonish-sandbox-openshell:dev
     network_policy:
       presets:
         - default
@@ -407,7 +407,7 @@ func writeConfigFile(dir, platformDSN, suffix, bifrostURL, jwtSecret string) err
     control_plane_namespace: %s
     overlay_mode: fuse
     privileged_pods: true
-    sandbox_image: schardosin/astonish-sandbox-base:dev
+    sandbox_image: ghcr.io/sap/astonish-sandbox-base:dev
     layers_pvc_name: astonish-layers
     uppers_pvc_name: astonish-uppers
 `, kubeconfigPath, sandboxNS, controlPlaneNS)


### PR DESCRIPTION
## Summary

Switch all Docker image publishing from Docker Hub (`schardosin/*`) to GitHub Container Registry (`ghcr.io/sap/*`) per SAP Open Source guidelines for container image releases.

## Changes

### GitHub Actions Workflows
- **docker-images.yml**: Replaced Docker Hub login with ghcr.io (`GITHUB_TOKEN`), added `docker/metadata-action` for automatic OCI labels (source, description, license), added `actions/attest-build-provenance@v1` attestation for each image
- **beta-release.yml**: Same migration pattern for all 4 Docker build jobs

### Go Source (Runtime Defaults)
- `pkg/sandbox/incus/docker.go` — `DockerImageRepo` → `ghcr.io/sap/astonish-incus`
- `pkg/sandbox/openshell/backend.go` — Default → `ghcr.io/sap/astonish-sandbox-openshell:latest`
- `pkg/sandbox/k8s/backend.go` — Default → `ghcr.io/sap/astonish-sandbox-base:latest`
- `pkg/config/app_config.go` — Doc comments updated

### Infrastructure
- `Makefile` — `DOCKER_REGISTRY` default → `ghcr.io/sap`
- All Helm values files (`values.yaml`, `values-dev-proxmox.yaml`, `values-e2e.yaml`, `values-e2e-openshell.yaml`)
- Dockerfile build example comments

### Tests & Docs
- Test fixtures in `imagebuilder_test.go`, `k8s/image_test.go`, `sandbox_backend_test.go`, `node_tool_test.go`, e2eboot configs
- Architecture docs, website deployment docs, config reference

## Image Name Mapping

| Old (Docker Hub) | New (ghcr.io) |
|-----------------|---------------|
| `schardosin/astonish` | `ghcr.io/sap/astonish` |
| `schardosin/astonish-incus` | `ghcr.io/sap/astonish-incus` |
| `schardosin/astonish-sandbox-base` | `ghcr.io/sap/astonish-sandbox-base` |
| `schardosin/astonish-sandbox-openshell` | `ghcr.io/sap/astonish-sandbox-openshell` |

## Post-Merge Manual Steps

1. Remove `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets from repo settings
2. After the first successful push to ghcr.io, configure package visibility and permissions in the GitHub package settings per the SAP guide

## Testing

- `go build ./...` — passes
- All related unit tests pass (`TestImageRef`, `TestImagePullPolicy`, `TestGenerateDockerfile`, `TestResolveTemplateImageWith`, `TestGetClientFromContext`)