### PR TITLE
fix: Added schema name as field to the team setup

### DIFF
--- a/cmd/astonish/setup.go
+++ b/cmd/astonish/setup.go
@@ -2066,10 +2066,11 @@ func handleSQLitePlatformSetup(cfg *config.AppConfig) error {
 	}
 	if existingTeam == nil {
 		team := &store.Team{
-			ID:        uuid.New().String(),
-			Name:      teamName,
-			Slug:      teamSlug,
-			CreatedAt: now,
+			ID:         uuid.New().String(),
+			Name:       teamName,
+			Slug:       teamSlug,
+			SchemaName: entstore.TeamSchemaName(teamSlug),
+			CreatedAt:  now,
 		}
 		if err := orgStore.Teams().CreateTeam(ctx, team); err != nil {
 			return fmt.Errorf("create team: %w", err)


### PR DESCRIPTION
I've experienced a small issue when trying to run the setup. I always ran into the same issue, regardless of the input:
`Error: create team: org: validator failed for field "Team.schema_name": value is less than the required length`

The change of this PR fixes this issue. Afterwards, the setup went through without any issue.