### PR TITLE
fix: add missing SchemaName to team creation in SQLitePlatformInitHandler

### DIFF
--- a/pkg/api/platform_setup_handlers.go
+++ b/pkg/api/platform_setup_handlers.go
@@ -382,10 +382,11 @@ func SQLitePlatformInitHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	team := &store.Team{
-		ID:        uuid.New().String(),
-		Name:      "General",
-		Slug:      "general",
-		CreatedAt: now,
+		ID:         uuid.New().String(),
+		Name:       "General",
+		Slug:       "general",
+		SchemaName: entstore.TeamSchemaName("general"),
+		CreatedAt:  now,
 	}
 	if err := orgStore.Teams().CreateTeam(ctx, team); err != nil {
 		respondJSON(w, http.StatusInternalServerError, PlatformInitResponse{


### PR DESCRIPTION
## Problem

The `SQLitePlatformInitHandler` in `pkg/api/platform_setup_handlers.go` creates the default "General" team without setting the `SchemaName` field. The Team Ent schema requires `schema_name` to be non-empty (`NotEmpty()` validator), so team creation fails with:

```
Failed to create team: org: validator failed for field "Team.schema_name": value is less than the required length
```

This is the same bug reported and fixed in `cmd/astonish/setup.go` by #325, but in the HTTP-based platform initialization handler.

## Fix

Added `SchemaName: entstore.TeamSchemaName("general")` to the team struct literal, consistent with all other team creation call sites in the codebase.

## Related

- #325 (same fix for `cmd/astonish/setup.go`)