### PR TITLE
Add chat harness panel, tutorial blueprint gate, and core ffmpeg

### DIFF
--- a/docs/architecture/browser.md
+++ b/docs/architecture/browser.md
@@ -134,7 +134,7 @@ Invariants:
 - Launch geometry stays at the configured viewport: KasmVNC `-geometry`, yaml `desktop.resolution`, Chrome `--window-size`, and CDP `SetViewport` should match. `browser_resize` only changes CDP metrics. The KasmVNC web UI may show a smaller client canvas (e.g. ~960×540 under HiDPI scaling); `xdpyinfo` / recording probe is authoritative.
 - Only one recording at a time; `Cleanup` / reconnect finalize an orphan recording.
 - Sandbox recordings write to `/tmp/astonish-recordings/*.mp4` (downloadable via sandbox PullFile). Local recordings write under `recordings/`.
-- Local Linux requires `ffmpeg` + `xdpyinfo` (`x11-utils`) (+ Xvfb when headed without a physical display). Sandbox images install those with the browser stack.
+- Local Linux requires `ffmpeg` + `xdpyinfo` (`x11-utils`) (+ Xvfb when headed without a physical display). Sandboxes install `ffmpeg` as a core tool (`CoreToolInstallCommands`); `x11-utils` comes with the browser stack.
 
 ### Tutorial recording polish
 

--- a/docs/architecture/chat-rendering-pipeline.md
+++ b/docs/architecture/chat-rendering-pipeline.md
@@ -51,8 +51,8 @@ sequenceDiagram
     Backend-->>connectChat: SSE: event:text (summary chunks)
     Backend-->>connectChat: SSE: event:done
 
-    StudioChat->>StudioChat: Last agent message has artifacts →<br/>EmbeddedFileViewer inline + Files button
-    StudioChat->>User: Rendered: Agent bubble + EmbeddedFileViewer + Files button
+    StudioChat->>StudioChat: Last agent message has gated report →<br/>HarnessPlaceholder + HarnessPanel + Files button
+    StudioChat->>User: Rendered: Agent bubble + placeholder; report in side panel
 ```
 
 ## SSE Transport Layer
@@ -104,14 +104,14 @@ The backend emits **27 distinct event types** across `chat_runner.go` and `chat_
 | Event | Data Shape | Frontend Action |
 |-------|-----------|----------------|
 | `artifact` | `{path, toolName, fileName, fileType}` | Add to `sessionArtifacts`, show ArtifactCard |
-| `tutorial_scene_slideshow` | `{title, suite, drill, manifest_path, scenes[]}` | Persistent scene navigator card (`TutorialSceneSlideshowCard`); survives page refresh via `[tutorial_scene_slideshow]` session marker |
+| `tutorial_scene_slideshow` | `{title, suite, drill, manifest_path, scenes[]}` | Open HarnessPanel with TutorialSceneSlideshowCard; persists via `[tutorial_scene_slideshow]` session marker |
 | `image` | `{data, mimeType}` | Render inline `<img>` |
 
 ### App Preview Events
 
 | Event | Data Shape | Frontend Action |
 |-------|-----------|----------------|
-| `app_preview` | `{code, title, description, version, appId}` | Finalize streaming text, render AppPreviewCard |
+| `app_preview` | `{code, title, description, version, appId}` | Finalize streaming text, open HarnessPanel with AppPreviewCard |
 | `app_done` / `app_saved` | `{name, path}` | Clear active app, show saved confirmation |
 
 ### Delegation Events
@@ -164,11 +164,11 @@ graph TD
     end
 
     subgraph "Message Types (React State)"
-        M1 --> C1["ReactMarkdown bubble<br/>(+ EmbeddedFileViewer if artifacts)"]
+        M1 --> C1["ReactMarkdown bubble<br/>(+ report/video HarnessPlaceholder)"]
         M2 --> C2[renderToolCard]
         M3 --> C2
         M4 --> C3[ArtifactCard]
-        M5 --> C4[AppPreviewCard]
+        M5 --> C4["HarnessPlaceholder → HarnessPanel(AppPreviewCard)"]
         M6 --> C5[Error div]
         M7 --> C6[Approval card]
         M8 --> C7[TaskPlanPanel]
@@ -180,10 +180,10 @@ graph TD
 | Message Type | Component | Notes |
 |-------------|-----------|-------|
 | `user` | Inline chat bubble | "You" label, plain text |
-| `agent` | `ReactMarkdown` bubble + `EmbeddedFileViewer` | Last agent message renders embedded file viewers when artifacts exist |
+| `agent` | `ReactMarkdown` bubble + report/video `HarnessPlaceholder` | Last agent message: gated reports and last-turn videos open in `HarnessPanel` |
 | `tool_call` | `renderToolCard()` | Collapsible tool invocation card |
 | `tool_result` | `renderToolCard()` | Collapsible tool response card |
-| `browser_handoff` | `BrowserView` | VNC proxy + page info |
+| `browser_handoff` | `HarnessPlaceholder` → `HarnessPanel`/`BrowserView` | VNC proxy fills the right panel |
 | `image` | Inline `<img>` | Base64 data URI |
 | `error` | Red error `<div>` | Plain text |
 | `error_info` | Structured error card | Title, reason, suggestion, raw error |
@@ -196,15 +196,17 @@ graph TD
 | `fleet_message` | Fleet chat bubble | Agent-colored markdown bubble |
 | `system` | System info card | Info icon + markdown |
 | `retry` | Orange retry badge | Attempt counter |
-| `artifact` | `ArtifactCard` | File notification (suppressed when embedded in last agent bubble) |
-| `app_preview` | `AppPreviewCard` | Sandboxed iframe with live React preview |
-| `distill_preview` | `DistillPreviewCard` | Flow YAML preview with save button |
+| `artifact` | `ArtifactCard` | File notification (suppressed when report/video is harnessed or embedded) |
+| `app_preview` | `HarnessPlaceholder` → `HarnessPanel`/`AppPreviewCard` | Compact stream card; full preview in ~1080px (resizable) right panel |
+| `distill_preview` | `HarnessPlaceholder` → `HarnessPanel`/`DistillPreviewCard` | Flow draft approval in right harness panel |
+| `tutorial_blueprint_preview` | `HarnessPlaceholder` → `HarnessPanel`/`TutorialBlueprintCard` | Tutorial blueprint approval in right harness panel |
+| `tutorial_scene_slideshow` | `HarnessPlaceholder` → `HarnessPanel`/`TutorialSceneSlideshowCard` | Post-record scene navigator in right harness panel |
 | `distill_saved` | Saved confirmation card | File path + copy button |
 | `app_saved` | Saved confirmation card | App name + path |
 
 ## The Report Pipeline
 
-Reports are rendered inline inside the last agent message bubble using `EmbeddedFileViewer`. There is no separate "ResultCard" wrapper -- artifacts appear directly below the agent's summary text.
+Gated markdown reports render in the right-hand **`HarnessPanel`** (~1080px preferred, user-resizable; chat keeps a ~380px floor), not as a full-width inline viewer in the chat stream. The chat stream shows a compact **`HarnessPlaceholder`** under the last agent bubble; clicking it re-focuses that report. The three-signal gate is unchanged — only the mount point moved from the agent bubble into `HarnessPanel`.
 
 ### How it works
 
@@ -226,14 +228,12 @@ sequenceDiagram
     Backend->>Frontend: SSE: text (summary chunks)
     Backend->>Frontend: SSE: done
 
-    Frontend->>Frontend: Last agent message + artifacts exist →<br/>Render EmbeddedFileViewer(s) below summary text
+    Frontend->>Frontend: Last agent message + gated report →<br/>HarnessPlaceholder in stream + HarnessPanel(EmbeddedFileViewer)
 ```
 
 ### The `embeddedArtifactPaths` memo
 
-When the session is done streaming and has artifacts, the `embeddedArtifactPaths` set is populated with all session artifact paths. This suppresses the inline `ArtifactCard` for those files, since they're already shown as `EmbeddedFileViewer`s inside the last agent message bubble.
-
-The logic is simple: if `!isStreaming` and `sessionArtifacts.length > 0`, find the last non-streaming agent message and embed all artifact paths.
+When the session is done streaming and has artifacts, the `embeddedArtifactPaths` set is populated for last-turn gated markdown reports and last-turn videos. That set suppresses the inline `ArtifactCard` for those files. Markdown reports and standalone videos mount in `HarnessPanel` via `reportHarnessPaths` / `videoHarnessPaths`. Slideshow-owned tutorial MP4s are excluded from `videoHarnessPaths` and play inside the harnessed `TutorialSceneSlideshowCard`.
 
 ### Export pipeline
 
@@ -264,13 +264,13 @@ graph TD
     F --> I["StudioChat embeddedArtifactPaths gate:<br/>last-turn AND fileType==='Markdown' AND isReport"]
     G --> I
     H --> I
-    I -->|gate passes| J[EmbeddedFileViewer<br/>inline in last agent bubble]
+    I -->|gate passes| J["HarnessPlaceholder in stream<br/>+ HarnessPanel(EmbeddedFileViewer)"]
     I -->|gate fails| K[ArtifactCard<br/>compact download tile]
 ```
 
 ### Gate rules (the contract surface)
 
-A markdown artifact is promoted to inline `EmbeddedFileViewer` rendering **iff all three** conditions hold:
+A markdown artifact is promoted to harness-panel `EmbeddedFileViewer` rendering **iff all three** conditions hold:
 
 1. The artifact event was emitted in the **last turn** (after the most recent user message). Earlier-turn edits never embed.
 2. `fileType === 'Markdown'`. Code, configs, scripts, JSON, etc. always render as `ArtifactCard`.
@@ -278,7 +278,7 @@ A markdown artifact is promoted to inline `EmbeddedFileViewer` rendering **iff a
 
 Any markdown artifact failing any of these conditions falls back to the compact `ArtifactCard` download tile.
 
-**Video (separate from the report gate):** last-turn artifacts with `fileType === 'Video'` (e.g. `browser_stop_recording` MP4s) also embed in `EmbeddedFileViewer` **unless** a `tutorial_scene_slideshow` message owns that path — tutorial `run_drill` MP4s play inside `TutorialSceneSlideshowCard` instead. The viewer loads bytes via `fetchArtifactBlob` (team-auth headers) into a blob URL and plays them with `<video controls>`. FilePanel uses the same player. Download labels use "Download Video" — never "Download as Markdown". Do not classify video as Markdown or set `isReport` for it.
+**Video (separate from the report gate):** last-turn artifacts with `fileType === 'Video'` (e.g. `browser_stop_recording` MP4s) open in `HarnessPanel` via `EmbeddedFileViewer` (`fillHeight`) **unless** a `tutorial_scene_slideshow` message owns that path — tutorial `run_drill` MP4s play inside the harnessed `TutorialSceneSlideshowCard` instead. The viewer loads bytes via `fetchArtifactBlob` (team-auth headers) into a blob URL and plays them with `<video controls>`. FilePanel uses the same player. Download labels use "Download Video" — never "Download as Markdown". Do not classify video as Markdown or set `isReport` for it.
 
 **Tutorial scene slideshow persistence:** after a successful tutorial `run_drill`, the backend reads `scene_manifest.json`, emits `tutorial_scene_slideshow` over SSE, and persists `[tutorial_scene_slideshow]{...}` in the session transcript (same pattern as `tutorial_blueprint_preview`). On reload, `eventsToMessages` reconstructs the card; sessions recorded before the marker shipped are backfilled by `injectTutorialSceneSlideshows` from persisted `run_drill` tool responses.
 
@@ -322,7 +322,7 @@ Visual apps use a different pipeline from reports. The LLM wraps generated React
 graph TD
     A["LLM generates text with<br/>```astonish-app fence"] --> B[Backend: detectAndEmitAppPreviews]
     B --> C["SSE: app_preview event<br/>{code, title, description, version}"]
-    C --> D[Frontend: AppPreviewCard]
+    C --> D[Frontend: HarnessPanel / AppPreviewCard]
     D --> E[Sandboxed iframe<br/>Sucrase + React runtime]
 
     A --> F["During streaming:<br/>AppCodeIndicator shows progress"]
@@ -337,7 +337,7 @@ During streaming, the agent message contains a partial `astonish-app` fence. The
 const appFenceRe = /```astonish-app\s*\n([\s\S]*?)(?:\n```|$)/
 ```
 
-When matched, it renders an `AppCodeIndicator` (pulsing "Generating app..." with expandable code view) instead of the raw fence text. After streaming completes, the `app_preview` event arrives and replaces the indicator with the full `AppPreviewCard`.
+When matched, it renders an `AppCodeIndicator` (pulsing "Generating app..." with expandable code view) instead of the raw fence text. After streaming completes, the `app_preview` event arrives and replaces the indicator with a stream `HarnessPlaceholder` plus the full `AppPreviewCard` in `HarnessPanel`.
 
 **This streaming interceptor is intentionally `astonish-app`-only.** Do not generalize it to other fence types without implementing the full backend event + frontend handler + ResultCard integration for that type.
 
@@ -455,8 +455,8 @@ These rules were established through bugs and fixes. Violating them will break t
 ### Report rendering
 
 1. **Reports must use `write_file`** -- The system prompt instructs the LLM to save reports to disk via `write_file`, then present a concise summary inline. Never use inline fences for reports.
-2. **Artifacts render as `EmbeddedFileViewer`** inside the last agent message bubble when `sessionArtifacts.length > 0` and the session is done streaming.
-3. **`embeddedArtifactPaths` suppresses inline `ArtifactCard`s** for files already shown as embedded viewers in the agent bubble.
+2. **Gated markdown reports and last-turn videos** open in `HarnessPanel` (with a stream `HarnessPlaceholder`) when `sessionArtifacts.length > 0` and the session is done streaming.
+3. **`embeddedArtifactPaths` suppresses inline `ArtifactCard`s** for files already shown via harness placeholders.
 
 ### Event handling
 
@@ -497,7 +497,10 @@ These rules were established through bugs and fixes. Violating them will break t
 | `web/src/components/StudioChat.tsx` | Main component -- SSE handlers, state, render loop |
 | `web/src/components/chat/chatTypes.ts` | Message type interfaces and ChatMsg union type |
 | `web/src/api/studioChat.ts` | `connectChat()`, `connectChatStream()`, artifact APIs |
-| `web/src/components/chat/EmbeddedFileViewer.tsx` | Inline file viewer with markdown rendering, download/export |
+| `web/src/components/chat/EmbeddedFileViewer.tsx` | File viewer with markdown rendering, download/export (harness fillHeight) |
+| `web/src/components/chat/HarnessPanel.tsx` | ~1080px preferred right panel (resizable) hosting Apps / Reports / Videos / Flow draft / Tutorial / Browser |
+| `web/src/components/chat/HarnessPlaceholder.tsx` | Compact clickable stream card that focuses the harness panel |
+| `web/src/components/chat/chatHarness.ts` | Latest-harness derivation and focus override helpers |
 | `web/src/components/chat/AppPreviewCard.tsx` | Sandboxed React preview in iframe |
 | `web/src/components/chat/AppCodeIndicator.tsx` | Streaming progress for app generation |
 | `web/src/components/chat/FilePanel.tsx` | Full-screen file viewer overlay |

--- a/docs/website/docs/agent/tools/browser.md
+++ b/docs/website/docs/agent/tools/browser.md
@@ -98,7 +98,7 @@ Configure browser settings via `astonish config edit` or Studio Settings.
 | `browser_stop_recording` | Stop recording and finalize the MP4 (emitted as a session artifact) |
 | `browser_recording_status` | Check whether a recording is in progress |
 
-Recording captures the **live X display** (probed via `xdpyinfo`). KasmVNC is locked against client resize with `desktop.resolution` set to the configured viewport (default **1920×1080**) so Studio’s VNC view cannot shrink the framebuffer. Call `browser_start_recording` before a scripted demo, then `browser_stop_recording` when finished. Local mode needs `ffmpeg` + `xdpyinfo`; sandboxes include them with the browser image.
+Recording captures the **live X display** (probed via `xdpyinfo`). KasmVNC is locked against client resize with `desktop.resolution` set to the configured viewport (default **1920×1080**) so Studio’s VNC view cannot shrink the framebuffer. Call `browser_start_recording` before a scripted demo, then `browser_stop_recording` when finished. Local mode needs `ffmpeg` + `xdpyinfo`; sandboxes install `ffmpeg` as a core tool and `x11-utils` with the browser stack.
 
 ## Example Workflow
 

--- a/pkg/agent/chat_agent.go
+++ b/pkg/agent/chat_agent.go
@@ -109,7 +109,8 @@ type ChatAgent struct {
 	pendingDistill       map[string]*distillPreview   // keyed by session ID
 	pendingDistillReview map[string]*DistillReview    // keyed by session ID — interactive review state
 	pendingTutorialBP    map[string]*TutorialBlueprintPending
-	traceMu              sync.Mutex // protects traceHistory, pendingDistill, pendingDistillReview, pendingTutorialBP
+	approvedTutorialBP   map[string]bool // session has creator-approved blueprint (sticky until re-present/cancel)
+	traceMu              sync.Mutex      // protects traceHistory, pendingDistill, pendingDistillReview, pendingTutorialBP, approvedTutorialBP
 
 	// Image side-channel: images stripped from tool results before they
 	// enter session history, available for channels to deliver to users.
@@ -218,6 +219,7 @@ func NewChatAgent(llm model.LLM, internalTools []tool.Tool, toolsets []tool.Tool
 		pendingDistill:       make(map[string]*distillPreview),
 		pendingDistillReview: make(map[string]*DistillReview),
 		pendingTutorialBP:    make(map[string]*TutorialBlueprintPending),
+		approvedTutorialBP:   make(map[string]bool),
 		activeApps:           make(map[string]*ActiveApp),
 	}
 }

--- a/pkg/agent/chat_agent_run.go
+++ b/pkg/agent/chat_agent_run.go
@@ -473,6 +473,18 @@ func (c *ChatAgent) Run(ctx agent.InvocationContext) iter.Seq2[*session.Event, e
 			})
 		}
 
+		// Hard-block validate_drill / save_drill / blueprint_to_tutorial_drill for
+		// mode:tutorial until the creator Approves a present_tutorial_blueprint card.
+		beforeToolCallbacks = append(beforeToolCallbacks, func(ctx tool.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+			blocked, result := CheckTutorialDrillToolGate(
+				t.Name(), args, c.HasTutorialBlueprintApproved(sessionID),
+			)
+			if blocked {
+				return result, nil
+			}
+			return nil, nil
+		})
+
 		// ── Auto-progress plan steps (before tool execution) ──
 		// When a plan is active, mark the first pending step as "running"
 		// when any non-delegate tool starts. This handles the initial

--- a/pkg/agent/chat_tutorial_blueprint.go
+++ b/pkg/agent/chat_tutorial_blueprint.go
@@ -40,9 +40,34 @@ func (c *ChatAgent) HasPendingTutorialBlueprint(sessionID string) bool {
 	return c.GetPendingTutorialBlueprint(sessionID) != nil
 }
 
-// CancelPendingTutorialBlueprint clears pending blueprint state.
+// CancelPendingTutorialBlueprint clears pending blueprint state (not the approved flag).
 func (c *ChatAgent) CancelPendingTutorialBlueprint(sessionID string) {
 	c.traceMu.Lock()
 	defer c.traceMu.Unlock()
 	delete(c.pendingTutorialBP, sessionID)
+}
+
+// MarkTutorialBlueprintApproved records that the creator approved a blueprint this session.
+// validate_drill / save_drill for mode:tutorial require this flag.
+func (c *ChatAgent) MarkTutorialBlueprintApproved(sessionID string) {
+	c.traceMu.Lock()
+	defer c.traceMu.Unlock()
+	if c.approvedTutorialBP == nil {
+		c.approvedTutorialBP = make(map[string]bool)
+	}
+	c.approvedTutorialBP[sessionID] = true
+}
+
+// HasTutorialBlueprintApproved reports whether this session has an approved blueprint.
+func (c *ChatAgent) HasTutorialBlueprintApproved(sessionID string) bool {
+	c.traceMu.Lock()
+	defer c.traceMu.Unlock()
+	return c.approvedTutorialBP[sessionID]
+}
+
+// ClearTutorialBlueprintApproved clears the approved flag (new present or cancel).
+func (c *ChatAgent) ClearTutorialBlueprintApproved(sessionID string) {
+	c.traceMu.Lock()
+	defer c.traceMu.Unlock()
+	delete(c.approvedTutorialBP, sessionID)
 }

--- a/pkg/agent/chat_tutorial_blueprint_test.go
+++ b/pkg/agent/chat_tutorial_blueprint_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import "testing"
+
+func TestTutorialBlueprintApprovedLifecycle(t *testing.T) {
+	c := &ChatAgent{}
+	const sid = "sess-approve"
+
+	if c.HasTutorialBlueprintApproved(sid) {
+		t.Fatal("expected no approval initially")
+	}
+
+	c.MarkTutorialBlueprintApproved(sid)
+	if !c.HasTutorialBlueprintApproved(sid) {
+		t.Fatal("expected approved after Mark")
+	}
+
+	// Pending clear must not clear approved.
+	c.SetPendingTutorialBlueprint(sid, &TutorialBlueprintPending{YAML: "x", Title: "t", Suite: "s"})
+	c.CancelPendingTutorialBlueprint(sid)
+	if !c.HasTutorialBlueprintApproved(sid) {
+		t.Fatal("CancelPending must not clear approved flag")
+	}
+
+	c.ClearTutorialBlueprintApproved(sid)
+	if c.HasTutorialBlueprintApproved(sid) {
+		t.Fatal("expected cleared after Clear")
+	}
+}
+
+func TestTutorialDrillGateUsesSessionApproval(t *testing.T) {
+	c := &ChatAgent{}
+	const sid = "sess-gate"
+	args := map[string]any{
+		"tests": []any{
+			map[string]any{"name": "open", "yaml": tutorialModeYAML},
+		},
+	}
+
+	blocked, result := CheckTutorialDrillToolGate("save_drill", args, c.HasTutorialBlueprintApproved(sid))
+	if !blocked {
+		t.Fatal("expected gate to block without approval")
+	}
+	if result["status"] != "error" {
+		t.Fatalf("status = %v", result["status"])
+	}
+
+	c.MarkTutorialBlueprintApproved(sid)
+	blocked, _ = CheckTutorialDrillToolGate("save_drill", args, c.HasTutorialBlueprintApproved(sid))
+	if blocked {
+		t.Fatal("expected gate to allow after MarkTutorialBlueprintApproved")
+	}
+}

--- a/pkg/agent/tutorial_drill_gate.go
+++ b/pkg/agent/tutorial_drill_gate.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"strings"
+
+	"github.com/SAP/astonish/pkg/config"
+)
+
+const tutorialBlueprintApprovalRequiredMsg = "Cannot use validate_drill / save_drill / blueprint_to_tutorial_drill for mode:tutorial until the creator Approves a tutorial blueprint. Call present_tutorial_blueprint and wait for Approve & generate."
+
+// DrillYAMLsContainTutorialMode reports whether any YAML parses as a drill with
+// drill_config.mode == "tutorial".
+func DrillYAMLsContainTutorialMode(yamls []string) bool {
+	for _, y := range yamls {
+		if y == "" {
+			continue
+		}
+		cfg, err := config.LoadAgentFromBytes([]byte(y))
+		if err != nil || cfg == nil || cfg.DrillConfig == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(cfg.DrillConfig.Mode), "tutorial") {
+			return true
+		}
+	}
+	return false
+}
+
+// TutorialBlueprintApprovalRequiredResult is the short-circuit tool result when
+// the approval gate blocks execution.
+func TutorialBlueprintApprovalRequiredResult() map[string]any {
+	return map[string]any{
+		"status":  "error",
+		"message": tutorialBlueprintApprovalRequiredMsg,
+	}
+}
+
+// CheckTutorialDrillToolGate blocks tutorial drill tools until the session has
+// an approved blueprint. Returns (true, result) when the tool must not run.
+func CheckTutorialDrillToolGate(toolName string, args map[string]any, approved bool) (blocked bool, result map[string]any) {
+	switch toolName {
+	case "blueprint_to_tutorial_drill":
+		if approved {
+			return false, nil
+		}
+		return true, TutorialBlueprintApprovalRequiredResult()
+
+	case "save_drill":
+		if approved || !DrillYAMLsContainTutorialMode(yamlsFromSaveDrillArgs(args)) {
+			return false, nil
+		}
+		return true, TutorialBlueprintApprovalRequiredResult()
+
+	case "validate_drill":
+		if approved || !DrillYAMLsContainTutorialMode(yamlsFromValidateDrillArgs(args)) {
+			return false, nil
+		}
+		return true, TutorialBlueprintApprovalRequiredResult()
+
+	default:
+		return false, nil
+	}
+}
+
+func yamlsFromSaveDrillArgs(args map[string]any) []string {
+	if args == nil {
+		return nil
+	}
+	raw, ok := args["tests"]
+	if !ok || raw == nil {
+		return nil
+	}
+	var out []string
+	switch tests := raw.(type) {
+	case []any:
+		for _, item := range tests {
+			out = append(out, yamlFieldFromAny(item))
+		}
+	case []map[string]any:
+		for _, item := range tests {
+			if y, ok := item["yaml"].(string); ok {
+				out = append(out, y)
+			}
+		}
+	}
+	return out
+}
+
+func yamlsFromValidateDrillArgs(args map[string]any) []string {
+	if args == nil {
+		return nil
+	}
+	raw, ok := args["test_yamls"]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch yamls := raw.(type) {
+	case []string:
+		return yamls
+	case []any:
+		out := make([]string, 0, len(yamls))
+		for _, item := range yamls {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func yamlFieldFromAny(item any) string {
+	switch m := item.(type) {
+	case map[string]any:
+		if y, ok := m["yaml"].(string); ok {
+			return y
+		}
+	case map[string]string:
+		return m["yaml"]
+	}
+	return ""
+}

--- a/pkg/agent/tutorial_drill_gate_test.go
+++ b/pkg/agent/tutorial_drill_gate_test.go
@@ -1,0 +1,115 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+const tutorialModeYAML = `type: drill
+suite: demo-tutorial
+description: Open Studio
+drill_config:
+  mode: tutorial
+  tags: [tutorial]
+nodes:
+  - name: open
+    type: tool
+    args:
+      tool: browser_navigate
+      url: https://example.com
+`
+
+const testModeYAML = `type: drill
+suite: demo
+description: Health
+drill_config:
+  tags: [smoke]
+nodes:
+  - name: s
+    type: tool
+    args:
+      tool: shell_command
+      command: echo hi
+    assert:
+      type: contains
+      expected: hi
+`
+
+func TestDrillYAMLsContainTutorialMode(t *testing.T) {
+	if !DrillYAMLsContainTutorialMode([]string{tutorialModeYAML}) {
+		t.Fatal("expected true for mode: tutorial")
+	}
+	if DrillYAMLsContainTutorialMode([]string{testModeYAML}) {
+		t.Fatal("expected false for non-tutorial drill")
+	}
+	if !DrillYAMLsContainTutorialMode([]string{testModeYAML, tutorialModeYAML}) {
+		t.Fatal("expected true when any YAML is tutorial")
+	}
+	if DrillYAMLsContainTutorialMode([]string{"not: yaml: [[[", ""}) {
+		t.Fatal("malformed YAML should not count as tutorial")
+	}
+	if DrillYAMLsContainTutorialMode(nil) {
+		t.Fatal("nil should be false")
+	}
+}
+
+func TestCheckTutorialDrillToolGate_SaveValidate(t *testing.T) {
+	saveArgs := map[string]any{
+		"tests": []any{
+			map[string]any{"name": "open", "yaml": tutorialModeYAML},
+		},
+	}
+	blocked, result := CheckTutorialDrillToolGate("save_drill", saveArgs, false)
+	if !blocked {
+		t.Fatal("save_drill with tutorial mode should block without approval")
+	}
+	if result["status"] != "error" {
+		t.Fatalf("status = %v, want error", result["status"])
+	}
+	msg, _ := result["message"].(string)
+	if !strings.Contains(msg, "present_tutorial_blueprint") {
+		t.Fatalf("message should mention present_tutorial_blueprint: %q", msg)
+	}
+
+	blocked, _ = CheckTutorialDrillToolGate("save_drill", saveArgs, true)
+	if blocked {
+		t.Fatal("save_drill should allow after approval")
+	}
+
+	validateArgs := map[string]any{
+		"test_yamls": []any{tutorialModeYAML},
+	}
+	blocked, _ = CheckTutorialDrillToolGate("validate_drill", validateArgs, false)
+	if !blocked {
+		t.Fatal("validate_drill with tutorial mode should block without approval")
+	}
+	blocked, _ = CheckTutorialDrillToolGate("validate_drill", validateArgs, true)
+	if blocked {
+		t.Fatal("validate_drill should allow after approval")
+	}
+
+	nonTutorialArgs := map[string]any{
+		"tests": []any{
+			map[string]any{"name": "health", "yaml": testModeYAML},
+		},
+	}
+	blocked, _ = CheckTutorialDrillToolGate("save_drill", nonTutorialArgs, false)
+	if blocked {
+		t.Fatal("non-tutorial save_drill should not require approval")
+	}
+}
+
+func TestCheckTutorialDrillToolGate_BlueprintToTutorial(t *testing.T) {
+	blocked, _ := CheckTutorialDrillToolGate("blueprint_to_tutorial_drill", map[string]any{}, false)
+	if !blocked {
+		t.Fatal("blueprint_to_tutorial_drill should block without approval")
+	}
+	blocked, _ = CheckTutorialDrillToolGate("blueprint_to_tutorial_drill", map[string]any{}, true)
+	if blocked {
+		t.Fatal("blueprint_to_tutorial_drill should allow after approval")
+	}
+	blocked, _ = CheckTutorialDrillToolGate("shell_command", map[string]any{}, false)
+	if blocked {
+		t.Fatal("unrelated tools must not be gated")
+	}
+}

--- a/pkg/api/chat_runner.go
+++ b/pkg/api/chat_runner.go
@@ -981,6 +981,8 @@ func (cr *ChatRunner) maybeEmitTutorialBlueprint(chatAgent *agent.ChatAgent, ses
 		Suite:  suite,
 		Scenes: scenes,
 	}
+	// New card requires a fresh Approve — clear any prior session approval.
+	chatAgent.ClearTutorialBlueprintApproved(cr.SessionID)
 	chatAgent.SetPendingTutorialBlueprint(cr.SessionID, pending)
 
 	scenePayload := make([]map[string]any, 0, len(scenes))

--- a/pkg/api/tutorial_blueprint_handlers.go
+++ b/pkg/api/tutorial_blueprint_handlers.go
@@ -35,14 +35,17 @@ func handleTutorialBlueprintIntent(
 			return true, ""
 		}
 		result, err := tools.BlueprintToTutorialDrillFromYAML(pending.YAML, "")
-		chatAgent.CancelPendingTutorialBlueprint(sessionID)
 		if err != nil {
+			chatAgent.CancelPendingTutorialBlueprint(sessionID)
 			errText := fmt.Sprintf("Failed to convert blueprint: %v", err)
 			SendSSE(w, flusher, "text", map[string]interface{}{"text": errText})
 			persistSessionMessage(r.Context(), sessionService, userID, sessionID, "model", errText)
 			SendSSE(w, flusher, "done", map[string]interface{}{"done": true})
 			return true, ""
 		}
+		// Mark approved before clearing pending so validate_drill/save_drill can proceed.
+		chatAgent.MarkTutorialBlueprintApproved(sessionID)
+		chatAgent.CancelPendingTutorialBlueprint(sessionID)
 		payload := map[string]any{
 			"title":          pending.Title,
 			"suite":          pending.Suite,
@@ -85,6 +88,7 @@ func handleTutorialBlueprintIntent(
 
 	case trimmed == "__tutorial_blueprint_cancel__":
 		persistSessionMessage(r.Context(), sessionService, userID, sessionID, "user", "Cancel blueprint")
+		chatAgent.ClearTutorialBlueprintApproved(sessionID)
 		chatAgent.CancelPendingTutorialBlueprint(sessionID)
 		responseText := "Tutorial blueprint review cancelled."
 		SendSSE(w, flusher, "text", map[string]interface{}{"text": responseText})

--- a/pkg/api/tutorial_blueprint_handlers_test.go
+++ b/pkg/api/tutorial_blueprint_handlers_test.go
@@ -71,6 +71,9 @@ func TestHandleTutorialBlueprintIntent_ApproveContinues(t *testing.T) {
 	if chatAgent.HasPendingTutorialBlueprint("sess-1") {
 		t.Fatal("pending blueprint should be cleared after approve")
 	}
+	if !chatAgent.HasTutorialBlueprintApproved("sess-1") {
+		t.Fatal("approve should mark session blueprint as approved")
+	}
 	body := rec.Body.String()
 	if !strings.Contains(body, "tutorial_blueprint_approved") {
 		t.Fatalf("expected tutorial_blueprint_approved SSE, got:\n%s", body)
@@ -109,6 +112,7 @@ func TestHandleTutorialBlueprintIntent_Cancel(t *testing.T) {
 		Title: "Open Studio",
 		Suite: "demo-tutorial",
 	})
+	chatAgent.MarkTutorialBlueprintApproved("sess-3")
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/studio/chat", nil)
 
@@ -123,6 +127,9 @@ func TestHandleTutorialBlueprintIntent_Cancel(t *testing.T) {
 	}
 	if chatAgent.HasPendingTutorialBlueprint("sess-3") {
 		t.Fatal("pending should be cleared on cancel")
+	}
+	if chatAgent.HasTutorialBlueprintApproved("sess-3") {
+		t.Fatal("cancel should clear approved blueprint flag")
 	}
 	body := rec.Body.String()
 	if !strings.Contains(body, "cancelled") {

--- a/pkg/sandbox/baseconfig/render_test.go
+++ b/pkg/sandbox/baseconfig/render_test.go
@@ -19,6 +19,7 @@ func TestRender_CoreToolsProducesExpectedCommands(t *testing.T) {
 	expected := []string{
 		"apt-get update",
 		"apt-get install -y git",
+		"ffmpeg",
 		"nodejs",
 		"curl -LsSf https://astral.sh/uv/install.sh | sh",
 		"apt-get clean",

--- a/pkg/sandbox/template.go
+++ b/pkg/sandbox/template.go
@@ -57,6 +57,8 @@ func CoreToolInstallCommands() [][]string {
 			// socat — required for exec-based TCP tunneling to container services
 			// (browser CDP, VNC proxy, sandbox HTTP proxy)
 			"socat",
+			// ffmpeg — standard multimedia tool (browser session recording, media processing)
+			"ffmpeg",
 			// Docker runtime (daemon + CLI + containerd) — required for
 			// containerized MCP servers and Docker-based workflows
 			"docker.io",

--- a/pkg/tools/tutorial_prompt.go
+++ b/pkg/tools/tutorial_prompt.go
@@ -47,6 +47,9 @@ Synthesia) is a later step. Do NOT treat every beat as a screen recording.
 9. After Approve & generate, refine screen steps with real clicks + content
    asserts → validate_drill → save_drill. Do not run_drill until dry-run passes.
 10. Never mix tutorial tags into default fleet smoke without a mode/tag filter.
+11. Tools REJECT validate_drill / save_drill (and blueprint_to_tutorial_drill)
+   for mode: tutorial until the creator clicks Approve — call
+   present_tutorial_blueprint first and wait for the card.
 
 ## INTERVIEW (do these before exploring / drafting)
 
@@ -198,7 +201,9 @@ rebuilding the stack.
    tutorial; mode must be tutorial.
 7. Follow the RECORDING PLAYBOOK: dry-run content first, warm-up unrecorded,
    multi-step reveal clicks (not cold navigates), asserts that fail on empty/error.
-8. Before run_drill, prep in order: use_sandbox_template (if declared) →
+8. Tools REJECT validate_drill / save_drill for mode: tutorial until Approve —
+   present_tutorial_blueprint first and wait for the card.
+9. Before run_drill, prep in order: use_sandbox_template (if declared) →
    inject_drill_credentials (if credentials declared) → run suite start
    script → dry-run green → then run_drill.
 `

--- a/web/src/AGENTS.md
+++ b/web/src/AGENTS.md
@@ -21,7 +21,7 @@ React 19 SPA for Astonish Studio. Mixed **TypeScript (`.ts`/`.tsx`)** and **lega
 ## Non-negotiable invariants
 
 ### StudioChat.tsx (report vs. artifact rendering)
-`StudioChat.tsx` implements the client side of the **three-signal report gate**. A markdown artifact renders inline (`EmbeddedFileViewer`) **only** when all three signals hold:
+`StudioChat.tsx` implements the client side of the **three-signal report gate**. A markdown artifact is promoted into the right-hand **`HarnessPanel`** (via `EmbeddedFileViewer`) **only** when all three signals hold:
 
 1. Emitted in the last turn (after the most recent user message).
 2. `fileType === 'Markdown'`.
@@ -29,7 +29,9 @@ React 19 SPA for Astonish Studio. Mixed **TypeScript (`.ts`/`.tsx`)** and **lega
 
 Anything failing any one of these renders as the compact `ArtifactCard`. **Do not widen the markdown report gate in the SPA.** If the backend regresses the marker, fix it in `pkg/api/chat_runner.go`, not by weakening the client check.
 
-Last-turn **Video** artifacts (e.g. `browser_stop_recording`) also embed via `EmbeddedFileViewer` with a native player — separate from the markdown report contract. FilePanel / EmbeddedFileViewer must not fetch video as text; use `fetchArtifactBlob` + `<video>`.
+The chat stream shows a compact `HarnessPlaceholder` for gated reports, Apps, Flow draft, Tutorial blueprint/slideshow, browser handoff, and last-turn videos. The full UI mounts in `HarnessPanel` (~1080px preferred, user-resizable; chat keeps a ~380px floor), which auto-opens on the latest harness emission and auto-collapses the session sidebar.
+
+Last-turn **Video** artifacts (e.g. `browser_stop_recording`) open in the harness via `EmbeddedFileViewer` with `fillHeight` — separate from the markdown report contract. Slideshow-owned tutorial MP4s stay inside `TutorialSceneSlideshowCard` (also harnessed). FilePanel / EmbeddedFileViewer must not fetch video as text; use `fetchArtifactBlob` + `<video>`.
 
 Authoritative reference: `docs/architecture/chat-rendering-pipeline.md`, "The Report Pipeline" section.
 

--- a/web/src/components/StudioChat.tsx
+++ b/web/src/components/StudioChat.tsx
@@ -18,19 +18,23 @@ import PlanPanel from './chat/PlanPanel'
 import FilePanel from './chat/FilePanel'
 import TodoPanel from './chat/TodoPanel'
 import AppsPanel from './chat/AppsPanel'
+import HarnessPanel from './chat/HarnessPanel'
+import HarnessPlaceholder from './chat/HarnessPlaceholder'
+import {
+  deriveLatestHarness,
+  harnessFocusEquals,
+  resolveHarnessFocus,
+  SIDEBAR_COLLAPSED_WIDTH,
+  SIDEBAR_EXPANDED_WIDTH,
+  type HarnessFocus,
+} from './chat/chatHarness'
 import SessionMemoryPanel from './SessionMemoryPanel'
 import SessionSidebar from './chat/SessionSidebar'
 import { listSessionMemories } from '../api/platform'
 import UsagePopover from './chat/UsagePopover'
 import type { TokenUsage } from './chat/UsagePopover'
-import BrowserView from './chat/BrowserView'
 import ArtifactCard from './chat/ArtifactCard'
-import DistillPreviewCard from './chat/DistillPreviewCard'
-import TutorialBlueprintCard from './chat/TutorialBlueprintCard'
-import TutorialSceneSlideshowCard from './chat/TutorialSceneSlideshowCard'
-import AppPreviewCard from './chat/AppPreviewCard'
 import AppCodeIndicator from './chat/AppCodeIndicator'
-import EmbeddedFileViewer from './chat/EmbeddedFileViewer'
 import NetworkDenialPrompt from './chat/NetworkDenialPrompt'
 import ModelCredentialBanner from './chat/ModelCredentialBanner'
 import SessionModelPicker from './chat/SessionModelPicker'
@@ -287,6 +291,15 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
   // Apps panel state
   const [appsPanelOpen, setAppsPanelOpen] = useState(false)
 
+  // Right-hand harness panel (Apps / Reports / Flow draft / Tutorial blueprint)
+  const [harnessOpen, setHarnessOpen] = useState(false)
+  const [manualHarnessFocus, setManualHarnessFocus] = useState<HarnessFocus | null>(null)
+  const prevHarnessIndexRef = useRef(-1)
+  const prevSidebarCollapsedRef = useRef(false)
+  const harnessAutoCollapsedRef = useRef(false)
+  const chatLayoutRef = useRef<HTMLDivElement>(null)
+  const [chatLayoutWidth, setChatLayoutWidth] = useState(0)
+
   // Token usage state (from API-reported UsageMetadata)
   const [tokenUsage, setTokenUsage] = useState<TokenUsage>({ inputTokens: 0, outputTokens: 0, totalTokens: 0 })
   const [sessionStartTime, setSessionStartTime] = useState<number | null>(null)
@@ -366,6 +379,100 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
     }
     return paths
   }, [messages, isStreaming, sessionArtifacts])
+
+  // Markdown reports that belong in the harness panel (same three-signal gate).
+  const reportHarnessPaths = useMemo(() => {
+    const paths = new Set<string>()
+    for (const p of embeddedArtifactPaths) {
+      const a = sessionArtifacts.find(sa => sa.path === p)
+      if (a && a.fileType === 'Markdown' && a.isReport) paths.add(p)
+    }
+    return paths
+  }, [embeddedArtifactPaths, sessionArtifacts])
+
+  // Last-turn videos for the harness (embeddedArtifactPaths already excludes slideshow-owned).
+  const videoHarnessPaths = useMemo(() => {
+    const paths = new Set<string>()
+    for (const p of embeddedArtifactPaths) {
+      const a = sessionArtifacts.find(sa => sa.path === p)
+      if (a && a.fileType === 'Video') paths.add(p)
+    }
+    return paths
+  }, [embeddedArtifactPaths, sessionArtifacts])
+
+  const latestHarness = useMemo(
+    () => deriveLatestHarness(messages, reportHarnessPaths, videoHarnessPaths),
+    [messages, reportHarnessPaths, videoHarnessPaths],
+  )
+
+  const effectiveHarnessFocus = useMemo(
+    () => resolveHarnessFocus(latestHarness, manualHarnessFocus),
+    [latestHarness, manualHarnessFocus],
+  )
+
+  const openHarness = useCallback((focus: HarnessFocus) => {
+    setManualHarnessFocus(focus)
+    setHarnessOpen(true)
+    setFilePanelOpen(false)
+    setTodoPanelOpen(false)
+    setAppsPanelOpen(false)
+    if (!harnessAutoCollapsedRef.current) {
+      prevSidebarCollapsedRef.current = sidebarCollapsed
+      harnessAutoCollapsedRef.current = true
+      setSidebarCollapsed(true)
+    }
+  }, [sidebarCollapsed])
+
+  const closeHarness = useCallback(() => {
+    setHarnessOpen(false)
+    setManualHarnessFocus(null)
+    if (harnessAutoCollapsedRef.current) {
+      setSidebarCollapsed(prevSidebarCollapsedRef.current)
+      harnessAutoCollapsedRef.current = false
+    }
+  }, [])
+
+  // Auto-open harness when a newer harness item is emitted; collapse session sidebar.
+  useEffect(() => {
+    if (!latestHarness) return
+    if (latestHarness.messageIndex <= prevHarnessIndexRef.current) return
+    prevHarnessIndexRef.current = latestHarness.messageIndex
+    setManualHarnessFocus(null)
+    setHarnessOpen(true)
+    setFilePanelOpen(false)
+    setTodoPanelOpen(false)
+    setAppsPanelOpen(false)
+    if (!harnessAutoCollapsedRef.current) {
+      prevSidebarCollapsedRef.current = sidebarCollapsed
+      harnessAutoCollapsedRef.current = true
+      setSidebarCollapsed(true)
+    }
+  // Intentionally omit sidebarCollapsed from deps — we only snapshot it when first opening.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [latestHarness])
+
+  // Reset harness tracking when the session changes.
+  useEffect(() => {
+    prevHarnessIndexRef.current = -1
+    setHarnessOpen(false)
+    setManualHarnessFocus(null)
+    harnessAutoCollapsedRef.current = false
+  }, [activeSessionId])
+
+  // Measure the StudioChat flex row for harness width clamping.
+  useEffect(() => {
+    const el = chatLayoutRef.current
+    if (!el) return
+    const update = () => setChatLayoutWidth(el.clientWidth)
+    update()
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(update)
+      ro.observe(el)
+      return () => ro.disconnect()
+    }
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
 
   // Latest plan message that actually has steps. The Todo button/panel are
   // shown only when this is non-null. A plan may be persisted without steps
@@ -2515,7 +2622,11 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
 
   return (
     <>
-    <div className="flex flex-1 overflow-hidden" style={{ background: 'var(--bg-primary)' }}>
+    <div
+      ref={chatLayoutRef}
+      className="flex flex-1 overflow-hidden"
+      style={{ background: 'var(--bg-primary)' }}
+    >
       {/* Session Sidebar */}
       <SessionSidebar
         sessions={filteredSessions}
@@ -2560,7 +2671,16 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
           {/* Todo button — shows plan steps in side panel (only when the latest plan has steps) */}
           {latestPlanWithSteps && (
           <button
-            onClick={() => { setTodoPanelOpen(!todoPanelOpen); if (!todoPanelOpen) { setFilePanelOpen(false); setAppsPanelOpen(false) } }}
+            onClick={() => {
+              const next = !todoPanelOpen
+              setTodoPanelOpen(next)
+              if (next) {
+                setFilePanelOpen(false)
+                setAppsPanelOpen(false)
+                setHarnessOpen(false)
+                setManualHarnessFocus(null)
+              }
+            }}
             className="flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors"
             style={{
               background: todoPanelOpen ? 'var(--accent-bg, rgba(59, 130, 246, 0.15))' : 'transparent',
@@ -2586,7 +2706,17 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
           {/* Files button — shown when session has artifacts */}
           {sessionArtifacts.length > 0 && (
             <button
-              onClick={() => { setFilePanelOpen(!filePanelOpen); setFilePanelInitialPath(null); if (!filePanelOpen) { setTodoPanelOpen(false); setAppsPanelOpen(false) } }}
+              onClick={() => {
+                const next = !filePanelOpen
+                setFilePanelOpen(next)
+                setFilePanelInitialPath(null)
+                if (next) {
+                  setTodoPanelOpen(false)
+                  setAppsPanelOpen(false)
+                  setHarnessOpen(false)
+                  setManualHarnessFocus(null)
+                }
+              }}
               className="flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors"
               style={{
                 background: filePanelOpen ? 'var(--accent-bg, rgba(59, 130, 246, 0.15))' : 'transparent',
@@ -2609,7 +2739,16 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
           {/* Apps button — shown when session has app previews */}
           {messages.some(m => m.type === 'app_preview') && (
             <button
-              onClick={() => { setAppsPanelOpen(!appsPanelOpen); if (!appsPanelOpen) { setTodoPanelOpen(false); setFilePanelOpen(false) } }}
+              onClick={() => {
+                const next = !appsPanelOpen
+                setAppsPanelOpen(next)
+                if (next) {
+                  setTodoPanelOpen(false)
+                  setFilePanelOpen(false)
+                  setHarnessOpen(false)
+                  setManualHarnessFocus(null)
+                }
+              }}
               className="flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors"
               style={{
                 background: appsPanelOpen ? 'var(--accent-bg, rgba(59, 130, 246, 0.15))' : 'transparent',
@@ -2820,20 +2959,49 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
                         )
                       })()}
                     </div>
-                    {/* Embedded file viewers for last-turn artifacts (last agent message only) */}
+                    {/* Last-turn report + video placeholders (full UI in harness panel) */}
                     {isLastAgent && (
                       <div className="mt-3 space-y-3">
-                        {sessionArtifacts.filter(a => embeddedArtifactPaths.has(a.path)).map(a => (
-                          <EmbeddedFileViewer
-                            key={a.path}
-                            artifact={a}
-                            sessionId={activeSessionId}
-                            onOpenInPanel={(path) => {
-                              setFilePanelInitialPath(path)
-                              setFilePanelOpen(true)
-                            }}
-                          />
-                        ))}
+                        {sessionArtifacts.filter(a => reportHarnessPaths.has(a.path)).map(a => {
+                          const artifactMsgIdx = messages.findIndex(
+                            m => m.type === 'artifact' && (m as ArtifactMessage).path === a.path,
+                          )
+                          const focus: HarnessFocus = {
+                            kind: 'report',
+                            path: a.path,
+                            messageIndex: artifactMsgIdx >= 0 ? artifactMsgIdx : messages.length,
+                          }
+                          return (
+                            <HarnessPlaceholder
+                              key={a.path}
+                              focus={focus}
+                              title={a.reportTitle || a.fileName || a.path}
+                              subtitle="Open in side panel"
+                              isFocused={harnessOpen && harnessFocusEquals(effectiveHarnessFocus, focus)}
+                              onOpen={openHarness}
+                            />
+                          )
+                        })}
+                        {sessionArtifacts.filter(a => videoHarnessPaths.has(a.path)).map(a => {
+                          const artifactMsgIdx = messages.findIndex(
+                            m => m.type === 'artifact' && (m as ArtifactMessage).path === a.path,
+                          )
+                          const focus: HarnessFocus = {
+                            kind: 'video',
+                            path: a.path,
+                            messageIndex: artifactMsgIdx >= 0 ? artifactMsgIdx : messages.length,
+                          }
+                          return (
+                            <HarnessPlaceholder
+                              key={a.path}
+                              focus={focus}
+                              title={a.fileName || a.path}
+                              subtitle="Open in side panel"
+                              isFocused={harnessOpen && harnessFocusEquals(effectiveHarnessFocus, focus)}
+                              onOpen={openHarness}
+                            />
+                          )
+                        })}
                       </div>
                     )}
                     {sourceUrls.length > 0 && <SourceCitations urls={sourceUrls} />}
@@ -2847,18 +3015,17 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
 
               if (msg.type === 'browser_handoff') {
                 const handoff = msg as BrowserHandoffMessage
+                const focus: HarnessFocus = { kind: 'browser_handoff', messageIndex: index }
                 return (
-                  <BrowserView
-                    key={index}
-                    data={handoff}
-                    theme={theme}
-                    onDone={() => {
-                      // Replace with a completed marker
-                      setMessages((prev: ChatMsg[]) => prev.map((m, i) =>
-                        i === index ? { ...m, type: 'browser_handoff' } as BrowserHandoffMessage : m
-                      ))
-                    }}
-                  />
+                  <div key={index}>
+                    <HarnessPlaceholder
+                      focus={focus}
+                      title={handoff.reason || handoff.pageTitle || 'Browser session'}
+                      subtitle={handoff.pageUrl || 'Open in side panel'}
+                      isFocused={harnessOpen && harnessFocusEquals(effectiveHarnessFocus, focus)}
+                      onOpen={openHarness}
+                    />
+                  </div>
                 )
               }
 
@@ -3087,23 +3254,25 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
                       : (m as AppPreviewMessage).title === appMsg.title
                   )
                 )
-                // Only render the card on the LAST version's message to avoid duplicates
+                // Only render the placeholder on the LAST version's message to avoid duplicates
                 const lastVersion = allVersions[allVersions.length - 1]
                 if (lastVersion && lastVersion !== appMsg) {
-                  return null // Skip earlier versions — they'll be shown via version nav
+                  return null
                 }
-                const versionIdx = allVersions.length - 1 // Default to latest
-                // Check if this app is actively being refined
-                const isActive = activeAppId != null && (appMsg.appId === activeAppId)
+                const appId = appMsg.appId || appMsg.title
+                const focus: HarnessFocus = {
+                  kind: 'app',
+                  appId,
+                  messageIndex: index,
+                }
                 return (
                   <div key={index}>
-                    <AppPreviewCard
-                      data={appMsg}
-                      versions={allVersions.length > 1 ? allVersions : undefined}
-                      versionIndex={versionIdx}
-                      isActive={isActive}
-                      onSave={isActive ? (name: string) => sendMessage(`__app_save__:${name}`) : undefined}
-                      sessionId={activeSessionId}
+                    <HarnessPlaceholder
+                      focus={focus}
+                      title={appMsg.title || 'App'}
+                      subtitle={allVersions.length > 1 ? `v${appMsg.version} · ${allVersions.length} versions` : `v${appMsg.version}`}
+                      isFocused={harnessOpen && harnessFocusEquals(effectiveHarnessFocus, focus)}
+                      onOpen={openHarness}
                     />
                   </div>
                 )
@@ -3111,29 +3280,15 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
 
               if (msg.type === 'distill_preview') {
                 const previewMsg = msg as DistillPreviewMessage
-                // A preview card is active (shows action buttons) when:
-                // 1. It's the last distill_preview in the message list
-                // 2. There's no distill_saved or cancel after it (review not concluded)
-                const isLastPreview = (() => {
-                  for (let j = index + 1; j < messages.length; j++) {
-                    const m = messages[j]
-                    if (m.type === 'distill_preview' || m.type === 'distill_saved') return false
-                  }
-                  return true
-                })()
+                const focus: HarnessFocus = { kind: 'distill', messageIndex: index }
                 return (
                   <div key={index}>
-                    <DistillPreviewCard
-                      data={previewMsg}
-                      isActive={isLastPreview}
-                      onSave={() => sendMessage('__distill_save__')}
-                      onRequestChanges={() => {
-                        if (inputRef.current) {
-                          inputRef.current.focus()
-                          inputRef.current.placeholder = 'Describe what you want to change in the flow...'
-                        }
-                      }}
-                      onCancel={() => sendMessage('__distill_cancel__')}
+                    <HarnessPlaceholder
+                      focus={focus}
+                      title={previewMsg.flowName || 'Flow draft'}
+                      subtitle={previewMsg.description || undefined}
+                      isFocused={harnessOpen && harnessFocusEquals(effectiveHarnessFocus, focus)}
+                      onOpen={openHarness}
                     />
                   </div>
                 )
@@ -3141,26 +3296,15 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
 
               if (msg.type === 'tutorial_blueprint_preview') {
                 const previewMsg = msg as TutorialBlueprintPreviewMessage
-                const isLastPreview = (() => {
-                  for (let j = index + 1; j < messages.length; j++) {
-                    const m = messages[j]
-                    if (m.type === 'tutorial_blueprint_preview' || m.type === 'tutorial_blueprint_approved') return false
-                  }
-                  return true
-                })()
+                const focus: HarnessFocus = { kind: 'tutorial_blueprint', messageIndex: index }
                 return (
                   <div key={index}>
-                    <TutorialBlueprintCard
-                      data={previewMsg}
-                      isActive={isLastPreview}
-                      onApprove={() => sendMessage('__tutorial_blueprint_approve__')}
-                      onRequestChanges={() => {
-                        if (inputRef.current) {
-                          inputRef.current.focus()
-                          inputRef.current.placeholder = 'Describe how to revise the Scene | Voiceover | Visual blueprint...'
-                        }
-                      }}
-                      onCancel={() => sendMessage('__tutorial_blueprint_cancel__')}
+                    <HarnessPlaceholder
+                      focus={focus}
+                      title={previewMsg.title || 'Tutorial blueprint'}
+                      subtitle={previewMsg.suite || undefined}
+                      isFocused={harnessOpen && harnessFocusEquals(effectiveHarnessFocus, focus)}
+                      onOpen={openHarness}
                     />
                   </div>
                 )
@@ -3186,11 +3330,15 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
 
               if (msg.type === 'tutorial_scene_slideshow') {
                 const slideshowMsg = msg as TutorialSceneSlideshowMessage
+                const focus: HarnessFocus = { kind: 'tutorial_slideshow', messageIndex: index }
                 return (
                   <div key={index}>
-                    <TutorialSceneSlideshowCard
-                      data={slideshowMsg}
-                      sessionId={activeSessionId}
+                    <HarnessPlaceholder
+                      focus={focus}
+                      title={slideshowMsg.title || slideshowMsg.drill || 'Tutorial scenes'}
+                      subtitle={slideshowMsg.suite ? `Suite: ${slideshowMsg.suite}` : 'Open in side panel'}
+                      isFocused={harnessOpen && harnessFocusEquals(effectiveHarnessFocus, focus)}
+                      onOpen={openHarness}
                     />
                   </div>
                 )
@@ -3477,6 +3625,49 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
           </form>
         </div>
       </div>
+
+      {/* Harness panel — ~1080px preferred, resizable; chat keeps a min floor */}
+      {harnessOpen && effectiveHarnessFocus && (
+        <HarnessPanel
+          focus={effectiveHarnessFocus}
+          messages={messages}
+          sessionArtifacts={sessionArtifacts}
+          activeAppId={activeAppId}
+          sessionId={activeSessionId}
+          theme={theme}
+          containerWidth={chatLayoutWidth}
+          sidebarWidth={sidebarCollapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_EXPANDED_WIDTH}
+          onClose={closeHarness}
+          onAppSave={(name: string) => sendMessage(`__app_save__:${name}`)}
+          onDistillSave={() => sendMessage('__distill_save__')}
+          onDistillRequestChanges={() => {
+            if (inputRef.current) {
+              inputRef.current.focus()
+              inputRef.current.placeholder = 'Describe what you want to change in the flow...'
+            }
+          }}
+          onDistillCancel={() => sendMessage('__distill_cancel__')}
+          onTutorialApprove={() => sendMessage('__tutorial_blueprint_approve__')}
+          onTutorialRequestChanges={() => {
+            if (inputRef.current) {
+              inputRef.current.focus()
+              inputRef.current.placeholder = 'Describe how to revise the Scene | Voiceover | Visual blueprint...'
+            }
+          }}
+          onTutorialCancel={() => sendMessage('__tutorial_blueprint_cancel__')}
+          onOpenReportInFiles={(path) => {
+            setFilePanelInitialPath(path)
+            setFilePanelOpen(true)
+            setHarnessOpen(false)
+            setManualHarnessFocus(null)
+          }}
+          onBrowserDone={(messageIndex) => {
+            setMessages((prev: ChatMsg[]) => prev.map((m, i) =>
+              i === messageIndex ? { ...m, type: 'browser_handoff' } as BrowserHandoffMessage : m
+            ))
+          }}
+        />
+      )}
 
       {/* File Panel — right side split panel for viewing artifacts */}
       {filePanelOpen && sessionArtifacts.length > 0 && (

--- a/web/src/components/chat/BrowserView.tsx
+++ b/web/src/components/chat/BrowserView.tsx
@@ -12,6 +12,8 @@ interface BrowserViewProps {
   data: BrowserHandoffData
   theme: string
   onDone: () => void
+  /** When true, fill parent height (harness panel) instead of fixed 500px iframe. */
+  fillHeight?: boolean
 }
 
 /**
@@ -20,7 +22,7 @@ interface BrowserViewProps {
  * (e.g. solve a CAPTCHA) while continuing to chat with the agent.
  * Click "Done" to end the visual sharing session.
  */
-export default function BrowserView({ data, theme, onDone }: BrowserViewProps) {
+export default function BrowserView({ data, theme, onDone, fillHeight = false }: BrowserViewProps) {
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [isDone, setIsDone] = useState(false)
   const [iframeLoaded, setIframeLoaded] = useState(false)
@@ -57,7 +59,9 @@ export default function BrowserView({ data, theme, onDone }: BrowserViewProps) {
 
   const containerClasses = isFullscreen
     ? 'fixed inset-0 z-50 flex flex-col'
-    : 'my-3 rounded-lg overflow-hidden flex flex-col'
+    : fillHeight
+      ? 'rounded-lg overflow-hidden flex flex-col h-full min-h-0'
+      : 'my-3 rounded-lg overflow-hidden flex flex-col'
 
   const containerStyle = isFullscreen
     ? {
@@ -67,6 +71,8 @@ export default function BrowserView({ data, theme, onDone }: BrowserViewProps) {
         border: '1px solid rgba(6, 182, 212, 0.3)',
         background: theme === 'dark' ? 'rgba(6, 182, 212, 0.03)' : 'rgba(6, 182, 212, 0.05)',
       }
+
+  const iframeMinHeight = isFullscreen || fillHeight ? 0 : '500px'
 
   return (
     <div className={containerClasses} style={containerStyle}>
@@ -123,7 +129,7 @@ export default function BrowserView({ data, theme, onDone }: BrowserViewProps) {
       </div>
 
       {/* KasmVNC iframe */}
-      <div className="relative flex-1" style={{ minHeight: isFullscreen ? 0 : '500px' }}>
+      <div className="relative flex-1 min-h-0" style={{ minHeight: iframeMinHeight }}>
         {!iframeLoaded && (
           <div className="absolute inset-0 flex items-center justify-center" style={{ color: 'var(--text-muted)' }}>
             <span className="text-sm">Loading browser view...</span>
@@ -133,7 +139,7 @@ export default function BrowserView({ data, theme, onDone }: BrowserViewProps) {
           src={data.vncProxyUrl}
           className="w-full h-full border-0"
           style={{
-            minHeight: isFullscreen ? '100%' : '500px',
+            minHeight: isFullscreen || fillHeight ? '100%' : '500px',
             opacity: iframeLoaded ? 1 : 0,
           }}
           onLoad={() => setIframeLoaded(true)}

--- a/web/src/components/chat/DistillPreviewCard.tsx
+++ b/web/src/components/chat/DistillPreviewCard.tsx
@@ -6,6 +6,8 @@ import type { DistillPreviewMessage } from './chatTypes'
 interface DistillPreviewCardProps {
   data: DistillPreviewMessage
   isActive?: boolean
+  /** When true, use full parent width (harness panel) instead of max-w-2xl. */
+  fillWidth?: boolean
   onSave: () => void
   onRequestChanges: () => void
   onCancel: () => void
@@ -88,7 +90,7 @@ function getTypeStyle(type: string) {
   return nodeTypeColors[lower] || { bg: 'var(--surface-muted)', text: 'var(--text-secondary)', border: 'var(--border-color)' }
 }
 
-export default function DistillPreviewCard({ data, isActive = false, onSave, onRequestChanges, onCancel }: DistillPreviewCardProps) {
+export default function DistillPreviewCard({ data, isActive = false, fillWidth = false, onSave, onRequestChanges, onCancel }: DistillPreviewCardProps) {
   const [showYaml, setShowYaml] = useState(false)
   const [explanationExpanded, setExplanationExpanded] = useState(true)
 
@@ -97,7 +99,7 @@ export default function DistillPreviewCard({ data, isActive = false, onSave, onR
 
   return (
     <div
-      className="my-3 rounded-xl overflow-hidden w-full max-w-2xl"
+      className={fillWidth ? 'rounded-xl overflow-hidden w-full' : 'my-3 rounded-xl overflow-hidden w-full max-w-2xl'}
       style={{
         border: '1px solid var(--border-color)',
         background: 'var(--bg-secondary)',

--- a/web/src/components/chat/EmbeddedFileViewer.tsx
+++ b/web/src/components/chat/EmbeddedFileViewer.tsx
@@ -29,10 +29,12 @@ function fileTypeBadgeStyle(fileType: string) {
 // Embedded file viewer for a single artifact — renders the file content inline
 // with a header bar (filename, type badge, download dropdown, fullscreen button).
 // Used inside agent message bubbles for markdown reports and last-turn media.
-export default function EmbeddedFileViewer({ artifact, sessionId, onOpenInPanel }: {
+export default function EmbeddedFileViewer({ artifact, sessionId, onOpenInPanel, fillHeight = false }: {
   artifact: SessionArtifact
   sessionId?: string | null
   onOpenInPanel?: (path: string) => void
+  /** When true, fill the parent height instead of capping content at 500px (harness panel). */
+  fillHeight?: boolean
 }) {
   const [content, setContent] = useState<string>('')
   const [loading, setLoading] = useState(true)
@@ -127,7 +129,7 @@ export default function EmbeddedFileViewer({ artifact, sessionId, onOpenInPanel 
 
   return (
     <div
-      className="rounded-lg overflow-hidden"
+      className={fillHeight ? 'rounded-lg overflow-hidden h-full flex flex-col min-h-0' : 'rounded-lg overflow-hidden'}
       style={{
         border: '1px solid var(--border-color)',
         background: 'var(--bg-primary)',
@@ -247,8 +249,8 @@ export default function EmbeddedFileViewer({ artifact, sessionId, onOpenInPanel 
 
       {/* File content */}
       <div
-        className="overflow-y-auto p-4"
-        style={{ maxHeight: mediaKind === 'video' ? 'none' : '500px' }}
+        className={fillHeight ? 'flex-1 min-h-0 overflow-y-auto p-4' : 'overflow-y-auto p-4'}
+        style={fillHeight || mediaKind === 'video' ? undefined : { maxHeight: '500px' }}
       >
         {mediaKind ? (
           <ArtifactMediaPlayer

--- a/web/src/components/chat/HarnessPanel.tsx
+++ b/web/src/components/chat/HarnessPanel.tsx
@@ -1,0 +1,386 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { X, GripVertical } from 'lucide-react'
+import AppPreviewCard from './AppPreviewCard'
+import DistillPreviewCard from './DistillPreviewCard'
+import TutorialBlueprintCard from './TutorialBlueprintCard'
+import TutorialSceneSlideshowCard from './TutorialSceneSlideshowCard'
+import EmbeddedFileViewer from './EmbeddedFileViewer'
+import BrowserView from './BrowserView'
+import {
+  appVersionsForFocus,
+  clampHarnessWidth,
+  harnessKindLabel,
+  messageAt,
+  readStoredHarnessWidth,
+  writeStoredHarnessWidth,
+  HARNESS_DEFAULT_WIDTH,
+  type HarnessFocus,
+} from './chatHarness'
+import type {
+  AppPreviewMessage,
+  BrowserHandoffMessage,
+  ChatMsg,
+  DistillPreviewMessage,
+  SessionArtifact,
+  TutorialBlueprintPreviewMessage,
+  TutorialSceneSlideshowMessage,
+} from './chatTypes'
+
+interface HarnessPanelProps {
+  focus: HarnessFocus
+  messages: ChatMsg[]
+  sessionArtifacts: SessionArtifact[]
+  activeAppId: string | null
+  sessionId?: string | null
+  theme?: string
+  /** Width of the StudioChat flex row (sidebar + chat + panels). */
+  containerWidth: number
+  /** Current session sidebar width in px. */
+  sidebarWidth: number
+  onClose: () => void
+  onAppSave?: (name: string) => void
+  onDistillSave?: () => void
+  onDistillRequestChanges?: () => void
+  onDistillCancel?: () => void
+  onTutorialApprove?: () => void
+  onTutorialRequestChanges?: () => void
+  onTutorialCancel?: () => void
+  onOpenReportInFiles?: (path: string) => void
+  onBrowserDone?: (messageIndex: number) => void
+}
+
+export default function HarnessPanel({
+  focus,
+  messages,
+  sessionArtifacts,
+  activeAppId,
+  sessionId,
+  theme = 'dark',
+  containerWidth,
+  sidebarWidth,
+  onClose,
+  onAppSave,
+  onDistillSave,
+  onDistillRequestChanges,
+  onDistillCancel,
+  onTutorialApprove,
+  onTutorialRequestChanges,
+  onTutorialCancel,
+  onOpenReportInFiles,
+  onBrowserDone,
+}: HarnessPanelProps) {
+  const [appVersionIndex, setAppVersionIndex] = useState(0)
+  const [preferredWidth, setPreferredWidth] = useState(readStoredHarnessWidth)
+  const [dragging, setDragging] = useState(false)
+  const [handleHovered, setHandleHovered] = useState(false)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const preferredWidthRef = useRef(preferredWidth)
+  preferredWidthRef.current = preferredWidth
+
+  const appId = focus.kind === 'app' ? focus.appId : ''
+  const appVersions =
+    focus.kind === 'app' ? appVersionsForFocus(messages, focus.appId) : []
+
+  const width = containerWidth > 0
+    ? clampHarnessWidth(preferredWidth, containerWidth, sidebarWidth)
+    : preferredWidth
+
+  // Always land on the latest version when the focused app gains a new revision.
+  useEffect(() => {
+    if (focus.kind !== 'app') return
+    setAppVersionIndex(Math.max(0, appVersions.length - 1))
+  }, [focus.kind, appId, appVersions.length])
+
+  const persistWidth = useCallback((next: number) => {
+    writeStoredHarnessWidth(next)
+  }, [])
+
+  const handleResizePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return
+    e.preventDefault()
+    const handleEl = e.currentTarget
+    handleEl.setPointerCapture(e.pointerId)
+    setDragging(true)
+    let latest = preferredWidthRef.current
+
+    const onMove = (ev: PointerEvent) => {
+      const panel = panelRef.current
+      const parent = panel?.parentElement
+      if (!parent) return
+      const parentRight = parent.getBoundingClientRect().right
+      const next = parentRight - ev.clientX
+      const clamped = clampHarnessWidth(next, containerWidth, sidebarWidth)
+      latest = clamped
+      preferredWidthRef.current = clamped
+      setPreferredWidth(clamped)
+    }
+
+    const onUp = (ev: PointerEvent) => {
+      setDragging(false)
+      setHandleHovered(false)
+      persistWidth(latest)
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+      try {
+        handleEl.releasePointerCapture(ev.pointerId)
+      } catch {
+        // already released
+      }
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onUp)
+  }, [containerWidth, sidebarWidth, persistWidth])
+
+  const handleResizeDoubleClick = useCallback(() => {
+    setPreferredWidth(HARNESS_DEFAULT_WIDTH)
+    persistWidth(HARNESS_DEFAULT_WIDTH)
+  }, [persistWidth])
+
+  const title = (() => {
+    switch (focus.kind) {
+      case 'app': {
+        const latest = appVersions[appVersions.length - 1]
+        return latest?.title || harnessKindLabel(focus.kind)
+      }
+      case 'report':
+      case 'video': {
+        const art = sessionArtifacts.find(a => a.path === focus.path)
+        return art?.reportTitle || art?.fileName || focus.path
+      }
+      case 'distill': {
+        const msg = messageAt<DistillPreviewMessage>(messages, focus.messageIndex)
+        return msg?.flowName || harnessKindLabel(focus.kind)
+      }
+      case 'tutorial_blueprint': {
+        const msg = messageAt<TutorialBlueprintPreviewMessage>(messages, focus.messageIndex)
+        return msg?.title || harnessKindLabel(focus.kind)
+      }
+      case 'tutorial_slideshow': {
+        const msg = messageAt<TutorialSceneSlideshowMessage>(messages, focus.messageIndex)
+        return msg?.title || msg?.drill || harnessKindLabel(focus.kind)
+      }
+      case 'browser_handoff': {
+        const msg = messageAt<BrowserHandoffMessage>(messages, focus.messageIndex)
+        return msg?.reason || msg?.pageTitle || harnessKindLabel(focus.kind)
+      }
+    }
+  })()
+
+  const fillBody = focus.kind === 'report' || focus.kind === 'video' || focus.kind === 'browser_handoff'
+
+  return (
+    <div
+      ref={panelRef}
+      data-testid="harness-panel"
+      data-harness-kind={focus.kind}
+      className="relative flex flex-col overflow-hidden flex-shrink-0"
+      style={{
+        width: `${width}px`,
+        borderLeft: '1px solid var(--border-color)',
+        background: 'var(--bg-primary)',
+        userSelect: dragging ? 'none' : undefined,
+      }}
+    >
+      {/* Left-edge resize handle — full-height hit target + mid-edge visual grip */}
+      <div
+        data-testid="harness-resize-handle"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize harness panel"
+        title="Drag to resize · double-click to reset"
+        onPointerDown={handleResizePointerDown}
+        onDoubleClick={handleResizeDoubleClick}
+        onPointerEnter={() => setHandleHovered(true)}
+        onPointerLeave={() => { if (!dragging) setHandleHovered(false) }}
+        className="absolute left-0 top-0 bottom-0 z-10 flex items-center justify-center"
+        style={{
+          width: '12px',
+          marginLeft: '-6px',
+          cursor: 'col-resize',
+          touchAction: 'none',
+        }}
+      >
+        <div
+          data-testid="harness-resize-grip"
+          className="pointer-events-none flex items-center justify-center rounded-full transition-colors"
+          style={{
+            width: '18px',
+            height: '40px',
+            background: 'var(--bg-secondary)',
+            border: `1px solid ${dragging || handleHovered ? 'var(--accent)' : 'var(--border-color)'}`,
+            color: dragging || handleHovered ? 'var(--accent)' : 'var(--text-muted)',
+            boxShadow: 'var(--shadow-soft)',
+          }}
+        >
+          <GripVertical size={14} style={{ color: 'inherit' }} />
+        </div>
+      </div>
+
+      <div
+        className="flex items-center justify-between px-4 py-3 flex-shrink-0"
+        style={{ borderBottom: '1px solid var(--border-color)', background: 'var(--bg-secondary)' }}
+      >
+        <div className="min-w-0">
+          <div className="text-[10px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+            {harnessKindLabel(focus.kind)}
+          </div>
+          <div className="text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
+            {title}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-1.5 rounded transition-colors cursor-pointer"
+          style={{ color: 'var(--text-muted)' }}
+          title="Close panel"
+          data-testid="harness-panel-close"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      <div
+        className={
+          fillBody
+            ? 'flex flex-col flex-1 min-h-0 overflow-hidden p-3'
+            : 'flex-1 overflow-auto p-3 min-h-0'
+        }
+      >
+        {focus.kind === 'app' && appVersions.length > 0 && (() => {
+          const data = appVersions[Math.min(appVersionIndex, appVersions.length - 1)] as AppPreviewMessage
+          const isActive = activeAppId != null && (data.appId === activeAppId || (!data.appId && data.title === activeAppId))
+          return (
+            <AppPreviewCard
+              data={data}
+              versions={appVersions.length > 1 ? appVersions : undefined}
+              versionIndex={appVersionIndex}
+              onNavigateVersion={setAppVersionIndex}
+              isActive={isActive}
+              onSave={isActive && onAppSave ? onAppSave : undefined}
+              sessionId={sessionId}
+            />
+          )
+        })()}
+
+        {(focus.kind === 'report' || focus.kind === 'video') && (() => {
+          const artifact = sessionArtifacts.find(a => a.path === focus.path)
+          if (!artifact) {
+            return (
+              <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                {focus.kind === 'video' ? 'Video' : 'Report'} not available.
+              </p>
+            )
+          }
+          return (
+            <div className="flex-1 min-h-0 h-full">
+              <EmbeddedFileViewer
+                artifact={artifact}
+                sessionId={sessionId}
+                fillHeight
+                onOpenInPanel={onOpenReportInFiles}
+              />
+            </div>
+          )
+        })()}
+
+        {focus.kind === 'distill' && (() => {
+          const previewMsg = messageAt<DistillPreviewMessage>(messages, focus.messageIndex)
+          if (!previewMsg || previewMsg.type !== 'distill_preview') {
+            return (
+              <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                Flow draft not available.
+              </p>
+            )
+          }
+          const isLastPreview = (() => {
+            for (let j = focus.messageIndex + 1; j < messages.length; j++) {
+              const m = messages[j]
+              if (m.type === 'distill_preview' || m.type === 'distill_saved') return false
+            }
+            return true
+          })()
+          return (
+            <DistillPreviewCard
+              data={previewMsg}
+              isActive={isLastPreview}
+              fillWidth
+              onSave={() => onDistillSave?.()}
+              onRequestChanges={() => onDistillRequestChanges?.()}
+              onCancel={() => onDistillCancel?.()}
+            />
+          )
+        })()}
+
+        {focus.kind === 'tutorial_blueprint' && (() => {
+          const previewMsg = messageAt<TutorialBlueprintPreviewMessage>(messages, focus.messageIndex)
+          if (!previewMsg || previewMsg.type !== 'tutorial_blueprint_preview') {
+            return (
+              <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                Tutorial blueprint not available.
+              </p>
+            )
+          }
+          const isLastPreview = (() => {
+            for (let j = focus.messageIndex + 1; j < messages.length; j++) {
+              const m = messages[j]
+              if (m.type === 'tutorial_blueprint_preview' || m.type === 'tutorial_blueprint_approved') return false
+            }
+            return true
+          })()
+          return (
+            <TutorialBlueprintCard
+              data={previewMsg}
+              isActive={isLastPreview}
+              onApprove={() => onTutorialApprove?.()}
+              onRequestChanges={() => onTutorialRequestChanges?.()}
+              onCancel={() => onTutorialCancel?.()}
+            />
+          )
+        })()}
+
+        {focus.kind === 'tutorial_slideshow' && (() => {
+          const slideshowMsg = messageAt<TutorialSceneSlideshowMessage>(messages, focus.messageIndex)
+          if (!slideshowMsg || slideshowMsg.type !== 'tutorial_scene_slideshow') {
+            return (
+              <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                Tutorial scenes not available.
+              </p>
+            )
+          }
+          return (
+            <TutorialSceneSlideshowCard
+              data={slideshowMsg}
+              sessionId={sessionId}
+              fillWidth
+            />
+          )
+        })()}
+
+        {focus.kind === 'browser_handoff' && (() => {
+          const handoff = messageAt<BrowserHandoffMessage>(messages, focus.messageIndex)
+          if (!handoff || handoff.type !== 'browser_handoff') {
+            return (
+              <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                Browser session not available.
+              </p>
+            )
+          }
+          return (
+            <div className="flex-1 min-h-0 h-full">
+              <BrowserView
+                data={handoff}
+                theme={theme}
+                fillHeight
+                onDone={() => onBrowserDone?.(focus.messageIndex)}
+              />
+            </div>
+          )
+        })()}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/chat/HarnessPlaceholder.tsx
+++ b/web/src/components/chat/HarnessPlaceholder.tsx
@@ -1,0 +1,101 @@
+import { AppWindow, FileText, Workflow, Clapperboard, Film, Monitor, ChevronRight } from 'lucide-react'
+import type { HarnessFocus } from './chatHarness'
+
+interface HarnessPlaceholderProps {
+  focus: HarnessFocus
+  title: string
+  subtitle?: string
+  isFocused?: boolean
+  onOpen: (focus: HarnessFocus) => void
+}
+
+function iconFor(kind: HarnessFocus['kind']) {
+  switch (kind) {
+    case 'app':
+      return AppWindow
+    case 'report':
+      return FileText
+    case 'video':
+      return Film
+    case 'distill':
+      return Workflow
+    case 'tutorial_blueprint':
+    case 'tutorial_slideshow':
+      return Clapperboard
+    case 'browser_handoff':
+      return Monitor
+  }
+}
+
+function kindPrefix(kind: HarnessFocus['kind']): string {
+  switch (kind) {
+    case 'app':
+      return 'App'
+    case 'report':
+      return 'Report'
+    case 'video':
+      return 'Video'
+    case 'distill':
+      return 'Flow draft'
+    case 'tutorial_blueprint':
+      return 'Tutorial blueprint'
+    case 'tutorial_slideshow':
+      return 'Tutorial scenes'
+    case 'browser_handoff':
+      return 'Browser'
+  }
+}
+
+export default function HarnessPlaceholder({
+  focus,
+  title,
+  subtitle,
+  isFocused = false,
+  onOpen,
+}: HarnessPlaceholderProps) {
+  const Icon = iconFor(focus.kind)
+
+  return (
+    <button
+      type="button"
+      data-testid="harness-placeholder"
+      data-harness-kind={focus.kind}
+      onClick={() => onOpen(focus)}
+      className="my-2 w-full max-w-xl flex items-center gap-3 px-3 py-2.5 rounded-xl text-left transition-colors cursor-pointer"
+      style={{
+        border: `1px solid ${isFocused ? 'var(--accent)' : 'var(--border-color)'}`,
+        background: isFocused
+          ? 'var(--accent-soft, rgba(59, 130, 246, 0.1))'
+          : 'var(--bg-secondary)',
+        boxShadow: 'var(--shadow-soft)',
+      }}
+    >
+      <div
+        className="flex items-center justify-center w-8 h-8 rounded-lg flex-shrink-0"
+        style={{
+          background: 'var(--accent-soft, rgba(59, 130, 246, 0.12))',
+          color: 'var(--accent)',
+        }}
+      >
+        <Icon size={16} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+          {kindPrefix(focus.kind)}: {title}
+        </div>
+        {subtitle && (
+          <div className="text-xs truncate mt-0.5" style={{ color: 'var(--text-muted)' }}>
+            {subtitle}
+          </div>
+        )}
+      </div>
+      <span
+        className="flex items-center gap-0.5 text-xs font-medium flex-shrink-0"
+        style={{ color: 'var(--accent)' }}
+      >
+        Open
+        <ChevronRight size={14} />
+      </span>
+    </button>
+  )
+}

--- a/web/src/components/chat/TutorialSceneSlideshowCard.tsx
+++ b/web/src/components/chat/TutorialSceneSlideshowCard.tsx
@@ -6,6 +6,8 @@ import type { TutorialSceneSlideshowMessage } from './chatTypes'
 interface TutorialSceneSlideshowCardProps {
   data: TutorialSceneSlideshowMessage
   sessionId?: string | null
+  /** When true, use full parent width (harness panel) instead of max-w-4xl. */
+  fillWidth?: boolean
 }
 
 function kindMeta(kind: string): { label: string; icon: typeof User; color: string } {
@@ -24,6 +26,7 @@ function kindMeta(kind: string): { label: string; icon: typeof User; color: stri
 export default function TutorialSceneSlideshowCard({
   data,
   sessionId,
+  fillWidth = false,
 }: TutorialSceneSlideshowCardProps) {
   const scenes = data.scenes || []
   const [index, setIndex] = useState(0)
@@ -62,7 +65,7 @@ export default function TutorialSceneSlideshowCard({
 
   return (
     <div
-      className="my-3 rounded-xl overflow-hidden w-full max-w-4xl"
+      className={fillWidth ? 'rounded-xl overflow-hidden w-full' : 'my-3 rounded-xl overflow-hidden w-full max-w-4xl'}
       style={{ border: '1px solid var(--border-color)', background: 'var(--bg-secondary)', boxShadow: 'var(--shadow-soft)' }}
     >
       <div className="px-4 py-3 flex items-center gap-2" style={{ borderBottom: '1px solid var(--border-color)' }}>

--- a/web/src/components/chat/chatHarness.ts
+++ b/web/src/components/chat/chatHarness.ts
@@ -1,0 +1,184 @@
+import type {
+  AppPreviewMessage,
+  ArtifactMessage,
+  ChatMsg,
+  DistillPreviewMessage,
+  TutorialBlueprintPreviewMessage,
+} from './chatTypes'
+
+/** Focus target for the right-hand chat harness panel. */
+export type HarnessFocus =
+  | { kind: 'app'; appId: string; messageIndex: number }
+  | { kind: 'report'; path: string; messageIndex: number }
+  | { kind: 'video'; path: string; messageIndex: number }
+  | { kind: 'distill'; messageIndex: number }
+  | { kind: 'tutorial_blueprint'; messageIndex: number }
+  | { kind: 'tutorial_slideshow'; messageIndex: number }
+  | { kind: 'browser_handoff'; messageIndex: number }
+
+/**
+ * Scan messages chronologically and return the most recently emitted harness
+ * item. `reportPaths` / `videoPaths` must already be gated (last-turn) —
+ * do not pass ungated artifact paths. Video paths must exclude slideshow-owned clips.
+ */
+export function deriveLatestHarness(
+  messages: ChatMsg[],
+  reportPaths: Set<string>,
+  videoPaths: Set<string> = new Set(),
+): HarnessFocus | null {
+  let latest: HarnessFocus | null = null
+
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i]
+    if (m.type === 'app_preview') {
+      const app = m as AppPreviewMessage
+      latest = {
+        kind: 'app',
+        appId: app.appId || app.title,
+        messageIndex: i,
+      }
+    } else if (m.type === 'distill_preview') {
+      latest = { kind: 'distill', messageIndex: i }
+    } else if (m.type === 'tutorial_blueprint_preview') {
+      latest = { kind: 'tutorial_blueprint', messageIndex: i }
+    } else if (m.type === 'tutorial_scene_slideshow') {
+      latest = { kind: 'tutorial_slideshow', messageIndex: i }
+    } else if (m.type === 'browser_handoff') {
+      latest = { kind: 'browser_handoff', messageIndex: i }
+    } else if (m.type === 'artifact') {
+      const art = m as ArtifactMessage
+      if (reportPaths.has(art.path)) {
+        latest = { kind: 'report', path: art.path, messageIndex: i }
+      } else if (videoPaths.has(art.path)) {
+        latest = { kind: 'video', path: art.path, messageIndex: i }
+      }
+    }
+  }
+
+  return latest
+}
+
+/**
+ * Manual placeholder click wins until a newer harness emission arrives
+ * (higher messageIndex).
+ */
+export function resolveHarnessFocus(
+  latest: HarnessFocus | null,
+  manual: HarnessFocus | null,
+): HarnessFocus | null {
+  if (!manual) return latest
+  if (!latest) return manual
+  if (latest.messageIndex > manual.messageIndex) return latest
+  return manual
+}
+
+/** Whether two focuses refer to the same harness item (for placeholder highlight). */
+export function harnessFocusEquals(
+  a: HarnessFocus | null | undefined,
+  b: HarnessFocus | null | undefined,
+): boolean {
+  if (!a || !b) return false
+  if (a.kind !== b.kind) return false
+  switch (a.kind) {
+    case 'app':
+      return a.appId === (b as Extract<HarnessFocus, { kind: 'app' }>).appId
+    case 'report':
+    case 'video':
+      return a.path === (b as Extract<HarnessFocus, { kind: 'report' | 'video' }>).path
+    case 'distill':
+    case 'tutorial_blueprint':
+    case 'tutorial_slideshow':
+    case 'browser_handoff':
+      return a.messageIndex === b.messageIndex
+  }
+}
+
+export function harnessKindLabel(kind: HarnessFocus['kind']): string {
+  switch (kind) {
+    case 'app':
+      return 'App'
+    case 'report':
+      return 'Report'
+    case 'video':
+      return 'Video'
+    case 'distill':
+      return 'Flow Draft'
+    case 'tutorial_blueprint':
+      return 'Tutorial Blueprint'
+    case 'tutorial_slideshow':
+      return 'Tutorial Scenes'
+    case 'browser_handoff':
+      return 'Browser'
+  }
+}
+
+export function appVersionsForFocus(
+  messages: ChatMsg[],
+  appId: string,
+): AppPreviewMessage[] {
+  return messages.filter(
+    (m): m is AppPreviewMessage =>
+      m.type === 'app_preview' &&
+      ((m.appId || m.title) === appId),
+  )
+}
+
+export function messageAt<T extends ChatMsg>(
+  messages: ChatMsg[],
+  index: number,
+): T | null {
+  if (index < 0 || index >= messages.length) return null
+  return messages[index] as T
+}
+
+/** Preferred / reset harness panel width (px). */
+export const HARNESS_DEFAULT_WIDTH = 1080
+/** Floor when the user drags the resize handle (px). */
+export const HARNESS_MIN_WIDTH = 480
+/** Chat column never thinner than this; harness shrinks first (px). */
+export const CHAT_MIN_WIDTH = 380
+/** Approximate collapsed session sidebar strip width (px). */
+export const SIDEBAR_COLLAPSED_WIDTH = 48
+/** Expanded session sidebar width (px). */
+export const SIDEBAR_EXPANDED_WIDTH = 280
+
+export const HARNESS_WIDTH_STORAGE_KEY = 'astonish.harnessPanelWidth'
+
+/**
+ * Clamp the harness panel width so chat keeps at least CHAT_MIN_WIDTH
+ * and the harness stays at least HARNESS_MIN_WIDTH when space allows.
+ */
+export function clampHarnessWidth(
+  preferred: number,
+  containerWidth: number,
+  sidebarWidth: number,
+): number {
+  const maxHarness = Math.max(0, containerWidth - sidebarWidth - CHAT_MIN_WIDTH)
+  const floor = Math.min(HARNESS_MIN_WIDTH, maxHarness)
+  const capped = Math.min(preferred, maxHarness)
+  return Math.max(floor, capped)
+}
+
+export function readStoredHarnessWidth(): number {
+  if (typeof localStorage === 'undefined') return HARNESS_DEFAULT_WIDTH
+  try {
+    const raw = localStorage.getItem(HARNESS_WIDTH_STORAGE_KEY)
+    if (raw == null) return HARNESS_DEFAULT_WIDTH
+    const n = Number(raw)
+    if (!Number.isFinite(n) || n <= 0) return HARNESS_DEFAULT_WIDTH
+    return n
+  } catch {
+    return HARNESS_DEFAULT_WIDTH
+  }
+}
+
+export function writeStoredHarnessWidth(width: number): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(HARNESS_WIDTH_STORAGE_KEY, String(Math.round(width)))
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+export type { AppPreviewMessage, DistillPreviewMessage, TutorialBlueprintPreviewMessage }

--- a/web/src/test/chatHarness.test.ts
+++ b/web/src/test/chatHarness.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest'
+import {
+  deriveLatestHarness,
+  harnessFocusEquals,
+  resolveHarnessFocus,
+  clampHarnessWidth,
+  HARNESS_DEFAULT_WIDTH,
+  HARNESS_MIN_WIDTH,
+  CHAT_MIN_WIDTH,
+  type HarnessFocus,
+} from '../components/chat/chatHarness'
+import type { ChatMsg } from '../components/chat/chatTypes'
+
+function app(title: string, version: number, appId?: string): ChatMsg {
+  return {
+    type: 'app_preview',
+    code: '<div/>',
+    title,
+    description: '',
+    version,
+    appId,
+  }
+}
+
+function distill(flowName: string): ChatMsg {
+  return {
+    type: 'distill_preview',
+    yaml: 'name: x',
+    flowName,
+    description: 'desc',
+    tags: [],
+    explanation: '',
+  }
+}
+
+function tutorial(title: string): ChatMsg {
+  return {
+    type: 'tutorial_blueprint_preview',
+    title,
+    suite: 'suite',
+    blueprintYaml: '',
+    scenes: [],
+  }
+}
+
+function slideshow(title: string): ChatMsg {
+  return {
+    type: 'tutorial_scene_slideshow',
+    title,
+    suite: 'suite',
+    drill: 'drill',
+    manifestPath: '/manifest.json',
+    scenes: [],
+  }
+}
+
+function browser(reason: string): ChatMsg {
+  return {
+    type: 'browser_handoff',
+    vncProxyUrl: 'http://vnc',
+    pageUrl: 'https://example.com',
+    pageTitle: 'Page',
+    reason,
+  }
+}
+
+function artifact(path: string, isReport = true): ChatMsg {
+  return {
+    type: 'artifact',
+    path,
+    toolName: 'write_file',
+    isReport,
+  }
+}
+
+describe('chatHarness', () => {
+  describe('deriveLatestHarness', () => {
+    it('returns null for empty messages', () => {
+      expect(deriveLatestHarness([], new Set())).toBeNull()
+    })
+
+    it('picks the most recent harness emission', () => {
+      const messages: ChatMsg[] = [
+        { type: 'user', content: 'hi' },
+        distill('flow_a'),
+        app('Dashboard', 1, 'app-1'),
+      ]
+      expect(deriveLatestHarness(messages, new Set())).toEqual({
+        kind: 'app',
+        appId: 'app-1',
+        messageIndex: 2,
+      })
+    })
+
+    it('switches from distill to app when app arrives later', () => {
+      const messages: ChatMsg[] = [distill('flow_a'), app('A', 1, 'a')]
+      expect(deriveLatestHarness(messages, new Set())?.kind).toBe('app')
+    })
+
+    it('updates app focus messageIndex on version bump', () => {
+      const messages: ChatMsg[] = [
+        app('Dashboard', 1, 'app-1'),
+        { type: 'user', content: 'tweak' },
+        app('Dashboard', 2, 'app-1'),
+      ]
+      expect(deriveLatestHarness(messages, new Set())).toEqual({
+        kind: 'app',
+        appId: 'app-1',
+        messageIndex: 2,
+      })
+    })
+
+    it('includes gated reports only', () => {
+      const messages: ChatMsg[] = [
+        artifact('/tmp/a.md', true),
+        artifact('/tmp/b.md', true),
+      ]
+      const gated = new Set(['/tmp/b.md'])
+      expect(deriveLatestHarness(messages, gated)).toEqual({
+        kind: 'report',
+        path: '/tmp/b.md',
+        messageIndex: 1,
+      })
+    })
+
+    it('ignores ungated report artifacts', () => {
+      const messages: ChatMsg[] = [artifact('/tmp/a.md', true)]
+      expect(deriveLatestHarness(messages, new Set())).toBeNull()
+    })
+
+    it('picks tutorial blueprint', () => {
+      const messages: ChatMsg[] = [tutorial('My Tutorial')]
+      expect(deriveLatestHarness(messages, new Set())).toEqual({
+        kind: 'tutorial_blueprint',
+        messageIndex: 0,
+      })
+    })
+
+    it('includes gated videos only', () => {
+      const messages: ChatMsg[] = [
+        artifact('/tmp/a.mp4', false),
+        artifact('/tmp/b.mp4', false),
+      ]
+      const videos = new Set(['/tmp/b.mp4'])
+      expect(deriveLatestHarness(messages, new Set(), videos)).toEqual({
+        kind: 'video',
+        path: '/tmp/b.mp4',
+        messageIndex: 1,
+      })
+    })
+
+    it('ignores videos not in videoPaths (e.g. slideshow-owned)', () => {
+      const messages: ChatMsg[] = [artifact('/tmp/scene.mp4', false)]
+      expect(deriveLatestHarness(messages, new Set(), new Set())).toBeNull()
+    })
+
+    it('picks browser handoff then switches to slideshow when later', () => {
+      const messages: ChatMsg[] = [browser('CAPTCHA'), slideshow('Scenes')]
+      expect(deriveLatestHarness(messages, new Set(), new Set())).toEqual({
+        kind: 'tutorial_slideshow',
+        messageIndex: 1,
+      })
+    })
+  })
+
+  describe('resolveHarnessFocus', () => {
+    const older: HarnessFocus = { kind: 'distill', messageIndex: 1 }
+    const newer: HarnessFocus = { kind: 'app', appId: 'x', messageIndex: 5 }
+
+    it('uses latest when no manual override', () => {
+      expect(resolveHarnessFocus(newer, null)).toEqual(newer)
+    })
+
+    it('keeps manual until a newer emission arrives', () => {
+      expect(resolveHarnessFocus(older, older)).toEqual(older)
+      const manualOlder: HarnessFocus = { kind: 'distill', messageIndex: 1 }
+      expect(resolveHarnessFocus(newer, manualOlder)).toEqual(newer)
+    })
+
+    it('keeps manual when it is the same or newer index', () => {
+      const manual: HarnessFocus = { kind: 'report', path: '/r.md', messageIndex: 5 }
+      expect(resolveHarnessFocus(newer, manual)).toEqual(manual)
+    })
+  })
+
+  describe('harnessFocusEquals', () => {
+    it('matches apps by appId', () => {
+      expect(
+        harnessFocusEquals(
+          { kind: 'app', appId: 'a', messageIndex: 1 },
+          { kind: 'app', appId: 'a', messageIndex: 9 },
+        ),
+      ).toBe(true)
+      expect(
+        harnessFocusEquals(
+          { kind: 'app', appId: 'a', messageIndex: 1 },
+          { kind: 'app', appId: 'b', messageIndex: 1 },
+        ),
+      ).toBe(false)
+    })
+
+    it('matches distill by messageIndex', () => {
+      expect(
+        harnessFocusEquals(
+          { kind: 'distill', messageIndex: 2 },
+          { kind: 'distill', messageIndex: 2 },
+        ),
+      ).toBe(true)
+      expect(
+        harnessFocusEquals(
+          { kind: 'distill', messageIndex: 2 },
+          { kind: 'distill', messageIndex: 3 },
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('clampHarnessWidth', () => {
+    const sidebar = 48
+
+    it('uses preferred width when space allows (default 1080)', () => {
+      // 1920 row: max = 1920 - 48 - 380 = 1492
+      expect(clampHarnessWidth(HARNESS_DEFAULT_WIDTH, 1920, sidebar)).toBe(1080)
+    })
+
+    it('caps harness so chat keeps CHAT_MIN_WIDTH', () => {
+      // 1200 row: max = 1200 - 48 - 380 = 772
+      expect(clampHarnessWidth(1080, 1200, sidebar)).toBe(772)
+      expect(1200 - sidebar - 772).toBe(CHAT_MIN_WIDTH)
+    })
+
+    it('enforces HARNESS_MIN_WIDTH when dragging below the floor', () => {
+      expect(clampHarnessWidth(200, 1920, sidebar)).toBe(HARNESS_MIN_WIDTH)
+    })
+
+    it('allows harness below HARNESS_MIN_WIDTH when viewport cannot fit both floors', () => {
+      // 700 row: max = 700 - 48 - 380 = 272
+      expect(clampHarnessWidth(1080, 700, sidebar)).toBe(272)
+    })
+  })
+})

--- a/web/src/test/scenarios/app-preview.test.tsx
+++ b/web/src/test/scenarios/app-preview.test.tsx
@@ -45,6 +45,20 @@ describe('App Preview Scenarios', () => {
       }, { timeout: 10000 })
     })
 
+    it('opens harness panel with app preview and shows placeholder in stream', async () => {
+      result = renderChat({
+        scenarioEvents: appGenerated.events as FixtureEvent[],
+      })
+
+      await result.sendMessage('Generate a dashboard')
+
+      await waitFor(() => {
+        expect(result.container.querySelector('[data-testid="harness-panel"]')).toBeTruthy()
+        expect(result.container.querySelector('[data-testid="harness-placeholder"]')).toBeTruthy()
+        expect(result.container.querySelector('[data-testid="app-preview-iframe"]')).toBeTruthy()
+      }, { timeout: 10000 })
+    })
+
     it('renders agent text before app preview', async () => {
       result = renderChat({
         scenarioEvents: appGenerated.events as FixtureEvent[],

--- a/web/src/test/scenarios/browser-handoff.test.tsx
+++ b/web/src/test/scenarios/browser-handoff.test.tsx
@@ -34,14 +34,14 @@ describe('Browser Handoff Scenarios', () => {
 
       await result.sendMessage('Check that page')
 
-      // The BrowserView header renders "Browser: {data.reason}"
-      // where reason comes from result.message = "CAPTCHA detected, please solve it"
+      // Placeholder + harness panel host BrowserView
       await waitFor(() => {
         const text = result.container.textContent || ''
         expect(text).toContain('CAPTCHA detected')
+        expect(result.container.querySelector('[data-testid="harness-panel"]')?.getAttribute('data-harness-kind')).toBe('browser_handoff')
+        expect(result.container.querySelector('[data-testid="harness-placeholder"]')).toBeTruthy()
       }, { timeout: 10000 })
 
-      // The BrowserView renders the page URL in the header
       await waitFor(() => {
         const text = result.container.textContent || ''
         expect(text).toContain('example.com/login')

--- a/web/src/test/scenarios/distill-flow.test.tsx
+++ b/web/src/test/scenarios/distill-flow.test.tsx
@@ -43,6 +43,22 @@ describe('Distill Flow Scenarios', () => {
       }, { timeout: 10000 })
     })
 
+    it('opens harness panel for distill preview with stream placeholder', async () => {
+      result = renderChat({
+        scenarioEvents: distillPreview.events as FixtureEvent[],
+      })
+
+      await result.sendMessage('Distill this conversation')
+
+      await waitFor(() => {
+        const panel = result.container.querySelector('[data-testid="harness-panel"]')
+        expect(panel).toBeTruthy()
+        expect(panel?.getAttribute('data-harness-kind')).toBe('distill')
+        expect(result.container.querySelector('[data-testid="harness-placeholder"]')).toBeTruthy()
+        expect(result.container.querySelector('[data-testid="flow-preview"]')).toBeTruthy()
+      }, { timeout: 10000 })
+    })
+
     it('shows tags on the preview card', async () => {
       result = renderChat({
         scenarioEvents: distillPreview.events as FixtureEvent[],

--- a/web/src/test/scenarios/harness-panel.test.tsx
+++ b/web/src/test/scenarios/harness-panel.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Harness panel layout: auto-open, sidebar collapse, placeholder re-focus.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { waitFor, fireEvent } from '@testing-library/react'
+import './scenarioSetup'
+import { renderChat } from '../helpers/renderChat'
+import type { RenderChatResult } from '../helpers/renderChat'
+import type { FixtureEvent } from '../helpers/sseSimulator'
+
+import appGenerated from '../fixtures/scenarios/apps/app-generated.json'
+import distillPreview from '../fixtures/scenarios/distill/distill-preview.json'
+
+vi.mock('../../components/chat/AppPreview', () => ({
+  default: ({ code }: { code: string }) => (
+    <div data-testid="app-preview-iframe">{code}</div>
+  ),
+}))
+
+vi.mock('../../components/FlowPreview', () => ({
+  default: () => <div data-testid="flow-preview">Flow Preview</div>,
+}))
+
+describe('Harness Panel Layout', () => {
+  let result: RenderChatResult
+
+  afterEach(() => {
+    if (result) result.cleanup()
+  })
+
+  it('collapses session sidebar when harness opens', async () => {
+    result = renderChat({
+      scenarioEvents: appGenerated.events as FixtureEvent[],
+    })
+
+    // Expanded sidebar shows "Conversations" header
+    await waitFor(() => {
+      expect(result.container.textContent).toContain('Conversations')
+      expect(
+        Array.from(result.container.querySelectorAll('button')).some(
+          b => b.getAttribute('title') === 'Hide sidebar',
+        ),
+      ).toBe(true)
+    })
+
+    await result.sendMessage('Generate a dashboard')
+
+    await waitFor(() => {
+      expect(result.container.querySelector('[data-testid="harness-panel"]')).toBeTruthy()
+      // Collapsed strip exposes expand control
+      expect(
+        Array.from(result.container.querySelectorAll('button')).some(
+          b => b.getAttribute('title') === 'Show sidebar',
+        ),
+      ).toBe(true)
+    }, { timeout: 10000 })
+  })
+
+  it('renders a resize handle on the harness panel', async () => {
+    result = renderChat({
+      scenarioEvents: appGenerated.events as FixtureEvent[],
+    })
+
+    await result.sendMessage('Generate a dashboard')
+
+    await waitFor(() => {
+      expect(result.container.querySelector('[data-testid="harness-panel"]')).toBeTruthy()
+      expect(result.container.querySelector('[data-testid="harness-resize-handle"]')).toBeTruthy()
+      expect(result.container.querySelector('[data-testid="harness-resize-grip"]')).toBeTruthy()
+    }, { timeout: 10000 })
+  })
+
+  it('re-focuses distill when its placeholder is clicked after an app', async () => {
+    // First play distill, then app — latest is app. Click distill placeholder to re-focus.
+    const combined: FixtureEvent[] = [
+      ...(distillPreview.events as FixtureEvent[]),
+    ]
+
+    result = renderChat({ scenarioEvents: combined })
+    await result.sendMessage('Distill this conversation')
+
+    await waitFor(() => {
+      expect(result.container.querySelector('[data-testid="harness-panel"]')?.getAttribute('data-harness-kind')).toBe('distill')
+    }, { timeout: 10000 })
+
+    // Close harness then re-open via placeholder
+    const closeBtn = result.container.querySelector('[data-testid="harness-panel-close"]')
+    expect(closeBtn).toBeTruthy()
+    fireEvent.click(closeBtn!)
+
+    await waitFor(() => {
+      expect(result.container.querySelector('[data-testid="harness-panel"]')).toBeNull()
+    })
+
+    const placeholder = result.container.querySelector('[data-testid="harness-placeholder"]')
+    expect(placeholder).toBeTruthy()
+    fireEvent.click(placeholder!)
+
+    await waitFor(() => {
+      const panel = result.container.querySelector('[data-testid="harness-panel"]')
+      expect(panel).toBeTruthy()
+      expect(panel?.getAttribute('data-harness-kind')).toBe('distill')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add a Studio Chat harness side panel that hosts browser, app preview, distill, reports, and other interactive surfaces instead of stacking them inline in the transcript.
- Gate tutorial drill saves on explicit blueprint approval so incomplete or unreviewed blueprints cannot be persisted.
- Install `ffmpeg` as a core sandbox tool via `CoreToolInstallCommands` so Incus and K8s `@base` match OpenShell parity (rebuild `@base` locally to pick it up).

## Test plan
- [ ] Open Studio Chat and confirm harness surfaces (browser, app preview, distill, report) open in the side panel rather than only inline
- [ ] Run a tutorial blueprint flow: save should require approval; reject/approve paths behave correctly
- [ ] Run frontend scenario tests: `harness-panel`, `browser-handoff`, `app-preview`, `distill-flow`
- [ ] Run Go tests for tutorial blueprint / drill gate packages
- [ ] After rebuilding `@base`, confirm `ffmpeg` is available inside an Incus/K8s guest (not the `astonish-incus` host container)