### PR TITLE
Fix SAP AI Core Gemini 400s and model-returned images

### DIFF
--- a/pkg/agent/chat_agent.go
+++ b/pkg/agent/chat_agent.go
@@ -481,9 +481,47 @@ func (c *ChatAgent) ForwardSubTaskEvent(event *session.Event) {
 	}
 }
 
+// EnqueueImagesFromContent extracts image/* InlineData parts from model (or
+// tool) content into the pending image queue for Studio SSE and channel delivery.
+// Parts are left intact so session history can reconstruct images on reload.
+// Thread-safe.
+func (c *ChatAgent) EnqueueImagesFromContent(content *genai.Content) {
+	if content == nil {
+		return
+	}
+	var imgs []ImageFromTool
+	for _, part := range content.Parts {
+		if part == nil || part.InlineData == nil || len(part.InlineData.Data) == 0 {
+			continue
+		}
+		mime := part.InlineData.MIMEType
+		if !strings.HasPrefix(mime, "image/") {
+			continue
+		}
+		format := strings.TrimPrefix(mime, "image/")
+		if format == "jpg" {
+			format = "jpeg"
+		}
+		if format == "" {
+			format = "png"
+		}
+		imgs = append(imgs, ImageFromTool{
+			Data:   part.InlineData.Data,
+			Format: format,
+		})
+	}
+	if len(imgs) == 0 {
+		return
+	}
+	c.imageMu.Lock()
+	c.pendingImages = append(c.pendingImages, imgs...)
+	c.imageMu.Unlock()
+}
+
 // DrainImages returns and clears all pending images that were extracted from
-// tool results during the current agent run. Thread-safe. The channel manager
-// calls this to retrieve images for delivery without relying on session events.
+// tool results or model InlineData during the current agent run. Thread-safe.
+// The channel manager calls this to retrieve images for delivery without
+// relying on session events.
 func (c *ChatAgent) DrainImages() []ImageFromTool {
 	c.imageMu.Lock()
 	defer c.imageMu.Unlock()

--- a/pkg/agent/chat_agent_test.go
+++ b/pkg/agent/chat_agent_test.go
@@ -16,6 +16,46 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestEnqueueImagesFromContent(t *testing.T) {
+	t.Parallel()
+	ca := &ChatAgent{}
+	ca.EnqueueImagesFromContent(&genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{Text: "caption"},
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{1, 2, 3}}},
+			{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte{4, 5}}},
+			{InlineData: &genai.Blob{MIMEType: "image/jpeg", Data: []byte{6, 7}}},
+			{InlineData: &genai.Blob{MIMEType: "image/jpg", Data: []byte{8}}},
+		},
+	})
+	imgs := ca.DrainImages()
+	if len(imgs) != 3 {
+		t.Fatalf("expected 3 images, got %d", len(imgs))
+	}
+	if imgs[0].Format != "png" || string(imgs[0].Data) != "\x01\x02\x03" {
+		t.Errorf("first image: %+v", imgs[0])
+	}
+	if imgs[1].Format != "jpeg" {
+		t.Errorf("second format=%q, want jpeg", imgs[1].Format)
+	}
+	if imgs[2].Format != "jpeg" {
+		t.Errorf("jpg should normalize to jpeg, got %q", imgs[2].Format)
+	}
+	if len(ca.DrainImages()) != 0 {
+		t.Error("second drain should be empty")
+	}
+}
+
+func TestEnqueueImagesFromContent_Nil(t *testing.T) {
+	t.Parallel()
+	ca := &ChatAgent{}
+	ca.EnqueueImagesFromContent(nil)
+	if len(ca.DrainImages()) != 0 {
+		t.Error("expected no images from nil content")
+	}
+}
+
 func TestExtractInputParams_NilTrace(t *testing.T) {
 	ca := &ChatAgent{}
 	params := ca.extractInputParams(context.Background(), "nodes: []", nil)

--- a/pkg/api/chat_handlers.go
+++ b/pkg/api/chat_handlers.go
@@ -112,11 +112,15 @@ type FleetMessageSummary struct {
 
 // StudioMessage is a simplified message for the frontend.
 type StudioMessage struct {
-	Type       string      `json:"type"`                 // user, agent, tool_call, tool_result, subtask_execution, plan, distill_preview, distill_saved, app_preview, system
+	Type       string      `json:"type"`                 // user, agent, tool_call, tool_result, image, subtask_execution, plan, distill_preview, distill_saved, app_preview, system
 	Content    string      `json:"content,omitempty"`    // text content
 	ToolName   string      `json:"toolName,omitempty"`   // for tool_call/tool_result
 	ToolArgs   interface{} `json:"toolArgs,omitempty"`   // for tool_call
 	ToolResult interface{} `json:"toolResult,omitempty"` // for tool_result
+
+	// image fields — model-returned or reconstructed InlineData images
+	Data     string `json:"data,omitempty"`     // base64-encoded image bytes
+	MimeType string `json:"mimeType,omitempty"` // e.g. image/png
 
 	// subtask_execution fields — populated for delegate_tasks history reconstruction
 	Events []SubTaskEventMsg `json:"events,omitempty"` // lifecycle + activity events

--- a/pkg/api/chat_handlers_test.go
+++ b/pkg/api/chat_handlers_test.go
@@ -46,6 +46,37 @@ func textEvent(invocationID, role, text string) *session.Event {
 	}
 }
 
+func TestEventsToMessages_ModelInlineImage(t *testing.T) {
+	t.Parallel()
+	png := []byte{0x89, 0x50, 0x4e, 0x47}
+	events := testEvents{
+		{
+			InvocationID: "inv-img",
+			LLMResponse: model.LLMResponse{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{{
+						InlineData: &genai.Blob{MIMEType: "image/png", Data: png},
+					}},
+				},
+			},
+		},
+	}
+	msgs := eventsToMessages(events, nil)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Type != "image" {
+		t.Fatalf("type=%q, want image", msgs[0].Type)
+	}
+	if msgs[0].MimeType != "image/png" {
+		t.Errorf("mimeType=%q", msgs[0].MimeType)
+	}
+	if msgs[0].Data == "" {
+		t.Error("expected base64 data")
+	}
+}
+
 func TestEventsToMessages_CoalescesSameInvocation(t *testing.T) {
 	// Two model text parts in the same invocation should be coalesced.
 	events := testEvents{

--- a/pkg/api/chat_runner.go
+++ b/pkg/api/chat_runner.go
@@ -474,6 +474,10 @@ func (cr *ChatRunner) Run(
 					cr.drainImagesAndFlowOutput(chatAgent, sessionService)
 				}
 			}
+			if !event.LLMResponse.Partial {
+				chatAgent.EnqueueImagesFromContent(event.LLMResponse.Content)
+				cr.drainImagesAndFlowOutput(chatAgent, sessionService)
+			}
 			return
 		}
 
@@ -504,6 +508,10 @@ func (cr *ChatRunner) Run(
 				cr.maybeEmitTutorialBlueprint(chatAgent, sessionService, part.FunctionResponse.Name, resp)
 				cr.maybeEmitTutorialSceneSlideshow(sessionService, part.FunctionResponse.Name, resp)
 			}
+		}
+		if !event.LLMResponse.Partial {
+			chatAgent.EnqueueImagesFromContent(event.LLMResponse.Content)
+			cr.drainImagesAndFlowOutput(chatAgent, sessionService)
 		}
 	}
 	defer func() { chatAgent.UIEventCallback = nil }()
@@ -695,7 +703,9 @@ runLoop:
 						"name":   part.FunctionResponse.Name,
 						"result": summarizeToolResult(resp),
 					})
-					cr.drainImagesAndFlowOutput(chatAgent, sessionService)
+					if cr.drainImagesAndFlowOutput(chatAgent, sessionService) > 0 {
+						hasContent = true
+					}
 					if cr.maybeEmitTutorialBlueprint(chatAgent, sessionService, part.FunctionResponse.Name, resp) {
 						// Blueprint card is up; wait for Approve / Request changes / Cancel
 						// (same hard-stop pattern as network_denial_hint).
@@ -769,6 +779,15 @@ runLoop:
 							}
 						}
 					}
+				}
+			}
+
+			// Model-returned images (e.g. Gemini image generation) arrive as
+			// InlineData parts — enqueue and emit SSE image events.
+			if !event.LLMResponse.Partial {
+				chatAgent.EnqueueImagesFromContent(event.LLMResponse.Content)
+				if cr.drainImagesAndFlowOutput(chatAgent, sessionService) > 0 {
+					hasContent = true
 				}
 			}
 		}
@@ -867,6 +886,10 @@ runLoop:
 						}
 						cr.maybeEmitTutorialSceneSlideshow(sessionService, part.FunctionResponse.Name, resp)
 					}
+				}
+				if !event.LLMResponse.Partial {
+					chatAgent.EnqueueImagesFromContent(event.LLMResponse.Content)
+					cr.drainImagesAndFlowOutput(chatAgent, sessionService)
 				}
 			}
 
@@ -1072,9 +1095,11 @@ func strVal(v any) string {
 	return s
 }
 
-// drainImagesAndFlowOutput drains images, flow output, and file artifacts from the chat agent and emits them as events.
-func (cr *ChatRunner) drainImagesAndFlowOutput(chatAgent *agent.ChatAgent, sessionService session.Service) {
-	for _, img := range chatAgent.DrainImages() {
+// drainImagesAndFlowOutput drains images, flow output, and file artifacts from
+// the chat agent and emits them as events. Returns the number of images emitted.
+func (cr *ChatRunner) drainImagesAndFlowOutput(chatAgent *agent.ChatAgent, sessionService session.Service) int {
+	images := chatAgent.DrainImages()
+	for _, img := range images {
 		mimeType := "image/png"
 		if img.Format == "jpeg" || img.Format == "jpg" {
 			mimeType = "image/jpeg"
@@ -1094,6 +1119,7 @@ func (cr *ChatRunner) drainImagesAndFlowOutput(chatAgent *agent.ChatAgent, sessi
 			"tool_name": file.ToolName,
 		})
 	}
+	return len(images)
 }
 
 // appPreviewFenceRe matches ```astonish-app code fences. It captures the code content

--- a/pkg/api/chat_utils.go
+++ b/pkg/api/chat_utils.go
@@ -160,24 +160,33 @@ func eventsToMessages(events session.Events, redactor *credentials.Redactor) []S
 				})
 				lastInvocationID = eventInvID
 			}
-			// Handle InlineData parts (file attachments) — attach to the most
-			// recent user message in this event.
-			if part.InlineData != nil && role == "user" {
-				att := AttachmentInfo{
-					Filename: part.InlineData.DisplayName,
-					MimeType: part.InlineData.MIMEType,
-					Size:     len(part.InlineData.Data),
-				}
-				// Include base64 data for images (enables inline thumbnail display)
-				if strings.HasPrefix(part.InlineData.MIMEType, "image/") {
-					att.Data = base64.StdEncoding.EncodeToString(part.InlineData.Data)
-				}
-				// Attach to the most recent user message
-				for i := len(messages) - 1; i >= 0; i-- {
-					if messages[i].Type == "user" {
-						messages[i].Attachments = append(messages[i].Attachments, att)
-						break
+			// Handle InlineData parts.
+			// User: file attachments on the most recent user message.
+			// Model: standalone image messages (e.g. Gemini image generation).
+			if part.InlineData != nil {
+				if role == "user" {
+					att := AttachmentInfo{
+						Filename: part.InlineData.DisplayName,
+						MimeType: part.InlineData.MIMEType,
+						Size:     len(part.InlineData.Data),
 					}
+					// Include base64 data for images (enables inline thumbnail display)
+					if strings.HasPrefix(part.InlineData.MIMEType, "image/") {
+						att.Data = base64.StdEncoding.EncodeToString(part.InlineData.Data)
+					}
+					// Attach to the most recent user message
+					for i := len(messages) - 1; i >= 0; i-- {
+						if messages[i].Type == "user" {
+							messages[i].Attachments = append(messages[i].Attachments, att)
+							break
+						}
+					}
+				} else if strings.HasPrefix(part.InlineData.MIMEType, "image/") && len(part.InlineData.Data) > 0 {
+					messages = append(messages, StudioMessage{
+						Type:     "image",
+						Data:     base64.StdEncoding.EncodeToString(part.InlineData.Data),
+						MimeType: part.InlineData.MIMEType,
+					})
 				}
 			}
 			if part.FunctionCall != nil {

--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -256,6 +256,26 @@ func (e *EmailChannel) Send(ctx context.Context, target channels.Target, msg cha
 		})
 	}
 
+	// Model-returned / tool screenshot images.
+	for _, img := range msg.Images {
+		if len(img.Data) == 0 {
+			continue
+		}
+		ext := img.Format
+		if ext == "" {
+			ext = "png"
+		}
+		if ext == "jpg" {
+			ext = "jpeg"
+		}
+		contentType := "image/" + ext
+		outgoing.Attachments = append(outgoing.Attachments, emailpkg.Attachment{
+			Filename:    fmt.Sprintf("image.%s", ext),
+			Data:        img.Data,
+			ContentType: contentType,
+		})
+	}
+
 	var outboundMessageID string
 	var err error
 

--- a/pkg/channels/email/images_test.go
+++ b/pkg/channels/email/images_test.go
@@ -1,0 +1,67 @@
+package email
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SAP/astonish/pkg/channels"
+	emailpkg "github.com/SAP/astonish/pkg/email"
+)
+
+// captureClient records the last OutgoingMessage sent.
+type captureClient struct {
+	last emailpkg.OutgoingMessage
+}
+
+func (c *captureClient) Connect(context.Context) error                          { return nil }
+func (c *captureClient) Close() error                                           { return nil }
+func (c *captureClient) IsConnected() bool                                      { return true }
+func (c *captureClient) Address() string                                        { return "bot@example.com" }
+func (c *captureClient) ListMessages(context.Context, emailpkg.ListOpts) ([]emailpkg.MessageSummary, error) {
+	return nil, nil
+}
+func (c *captureClient) ReadMessage(context.Context, string) (*emailpkg.Message, error) {
+	return nil, nil
+}
+func (c *captureClient) SearchMessages(context.Context, emailpkg.SearchQuery) ([]emailpkg.MessageSummary, error) {
+	return nil, nil
+}
+func (c *captureClient) Send(_ context.Context, msg emailpkg.OutgoingMessage) (string, error) {
+	c.last = msg
+	return "<id@test>", nil
+}
+func (c *captureClient) Reply(_ context.Context, _ string, _ bool, msg emailpkg.OutgoingMessage) (string, error) {
+	c.last = msg
+	return "<id@test>", nil
+}
+func (c *captureClient) MarkRead(context.Context, []string) error   { return nil }
+func (c *captureClient) MarkUnread(context.Context, []string) error { return nil }
+func (c *captureClient) Delete(context.Context, []string, bool) error {
+	return nil
+}
+
+func TestSend_AttachesImages(t *testing.T) {
+	t.Parallel()
+	cap := &captureClient{}
+	ch := &EmailChannel{client: cap}
+
+	err := ch.Send(context.Background(), channels.Target{ChatID: "user@example.com"}, channels.OutboundMessage{
+		Text: "Here is an image",
+		Images: []channels.ImageAttachment{
+			{Data: []byte{0x89, 0x50, 0x4e, 0x47}, Format: "png"},
+			{Data: []byte{0xff, 0xd8, 0xff}, Format: "jpg"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cap.last.Attachments) != 2 {
+		t.Fatalf("expected 2 attachments, got %d", len(cap.last.Attachments))
+	}
+	if cap.last.Attachments[0].Filename != "image.png" || cap.last.Attachments[0].ContentType != "image/png" {
+		t.Errorf("first attachment: %+v", cap.last.Attachments[0])
+	}
+	if cap.last.Attachments[1].Filename != "image.jpeg" || cap.last.Attachments[1].ContentType != "image/jpeg" {
+		t.Errorf("second attachment: %+v", cap.last.Attachments[1])
+	}
+}

--- a/pkg/channels/images_enqueue_test.go
+++ b/pkg/channels/images_enqueue_test.go
@@ -1,0 +1,40 @@
+package channels
+
+import (
+	"testing"
+
+	"github.com/SAP/astonish/pkg/agent"
+	"google.golang.org/genai"
+)
+
+// Verifies the manager wiring pattern: enqueue model InlineData then drain
+// into ImageAttachment — the same sequence used in handleInbound for orphan
+// image-only turns (no accompanying text).
+func TestEnqueueThenDrain_ModelInlineImage(t *testing.T) {
+	t.Parallel()
+	ca := &agent.ChatAgent{}
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{{
+			InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}},
+		}},
+	}
+	ca.EnqueueImagesFromContent(content)
+
+	var pending []ImageAttachment
+	for _, img := range ca.DrainImages() {
+		pending = append(pending, ImageAttachment{Data: img.Data, Format: img.Format})
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending image, got %d", len(pending))
+	}
+	if pending[0].Format != "png" || len(pending[0].Data) != 2 {
+		t.Errorf("unexpected attachment: %+v", pending[0])
+	}
+
+	// Orphan send shape used when text is empty.
+	out := OutboundMessage{Images: pending}
+	if len(out.Images) != 1 || out.Text != "" {
+		t.Errorf("orphan outbound: %+v", out)
+	}
+}

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -793,9 +793,9 @@ func (m *ChannelManager) handleInbound(ctx context.Context, msg InboundMessage) 
 			continue
 		}
 
-		// Scan for images in tool (function) responses. Images are stripped
-		// from tool results by the AfterToolCallback (to keep session history
-		// clean) and stashed in the ChatAgent's image queue. Drain them here.
+		// Collect images from tool results (stashed by AfterToolCallback) and
+		// from model InlineData parts (e.g. Gemini image generation).
+		m.agent.EnqueueImagesFromContent(event.LLMResponse.Content)
 		for _, img := range m.agent.DrainImages() {
 			pendingImages = append(pendingImages, ImageAttachment{
 				Data:   img.Data,

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -196,6 +196,8 @@ func Run(cfg RunConfig) error {
 	}
 	defer entStore.Close()
 	backend = entStore
+	// Persist/learn per-model token limits from provider 400 responses (SAP Vertex).
+	provider.SetSAPModelLimitsStore(entStore.ModelLimits())
 	logger.Printf("Storage backend: %s (platform mode)", appCfg.Storage.Backend)
 
 	// Run migrations

--- a/pkg/provider/context_window.go
+++ b/pkg/provider/context_window.go
@@ -11,7 +11,14 @@ import (
 	"github.com/SAP/astonish/pkg/provider/groq"
 	"github.com/SAP/astonish/pkg/provider/openrouter"
 	"github.com/SAP/astonish/pkg/provider/sap"
+	"github.com/SAP/astonish/pkg/store"
 )
+
+// SetSAPModelLimitsStore wires the durable learned-limits store into the SAP
+// AI Core provider (used to persist maxOutputTokens from Vertex 400s).
+func SetSAPModelLimitsStore(s store.ModelLimitsStore) {
+	sap.SetModelLimitsStore(s)
+}
 
 const DefaultContextWindow = 200_000
 

--- a/pkg/provider/llmerror/errors.go
+++ b/pkg/provider/llmerror/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -21,10 +22,34 @@ type LLMError struct {
 }
 
 func (e *LLMError) Error() string {
-	if e.Message != "" {
-		return fmt.Sprintf("%s: %d %s", e.Provider, e.StatusCode, e.Message)
+	msg := e.Message
+	if msg == "" {
+		msg = http.StatusText(e.StatusCode)
 	}
-	return fmt.Sprintf("%s: %d %s", e.Provider, e.StatusCode, http.StatusText(e.StatusCode))
+	// resp.Status is often "400 Bad Request" — avoid "400 400 Bad Request".
+	msg = strings.TrimPrefix(msg, strconv.Itoa(e.StatusCode)+" ")
+	base := fmt.Sprintf("%s: %d %s", e.Provider, e.StatusCode, msg)
+	if detail := truncateErrorBody(e.Body); detail != "" {
+		return base + ": " + detail
+	}
+	return base
+}
+
+// truncateErrorBody returns a short, single-line snippet of the provider
+// response body so callers see the real rejection reason (e.g. Gemini
+// INVALID_ARGUMENT details) instead of only the HTTP status text.
+func truncateErrorBody(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" || strings.HasPrefix(body, "<unreadable:") {
+		return ""
+	}
+	body = strings.ReplaceAll(body, "\n", " ")
+	body = strings.Join(strings.Fields(body), " ")
+	const maxLen = 400
+	if len(body) > maxLen {
+		return body[:maxLen] + "..."
+	}
+	return body
 }
 
 // NewLLMError creates an LLMError with automatic retryable classification.
@@ -84,14 +109,31 @@ func IsServerError(err error) bool {
 	return false
 }
 
-// IsContextOverflow returns true if the error is a 400 Bad Request that likely
-// indicates the request exceeded the model's context window. Providers return
-// 400 for various reasons, but when the compactor estimates token usage is high,
-// a 400 is almost certainly a context overflow.
+// IsContextOverflow returns true if the error looks like a context-window
+// overflow. Providers return 400 for many reasons (invalid schema, bad
+// arguments, etc.), so we require overflow-related keywords in the body or
+// message — a bare 400 is not enough.
 func IsContextOverflow(err error) bool {
 	var llmErr *LLMError
-	if errors.As(err, &llmErr) {
-		return llmErr.StatusCode == http.StatusBadRequest
+	if !errors.As(err, &llmErr) || llmErr.StatusCode != http.StatusBadRequest {
+		return false
+	}
+	haystack := strings.ToLower(llmErr.Message + " " + llmErr.Body)
+	for _, kw := range []string{
+		"context length",
+		"context window",
+		"maximum context",
+		"too many tokens",
+		"token limit",
+		"prompt is too long",
+		"input is too long",
+		"exceeds the maximum",
+		"max_tokens",
+		"context_length_exceeded",
+	} {
+		if strings.Contains(haystack, kw) {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/provider/llmerror/errors_test.go
+++ b/pkg/provider/llmerror/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -58,6 +59,28 @@ func TestLLMErrorString(t *testing.T) {
 	want2 := "openai: 500 Internal Server Error"
 	if got2 != want2 {
 		t.Errorf("Error() = %q, want %q", got2, want2)
+	}
+
+	// NewFromResponse uses resp.Status ("400 Bad Request") — don't double the code.
+	e3 := NewLLMError("sap-vertex", 400, "400 Bad Request", `{"error":{"message":"Unknown name \"additionalProperties\""}}`)
+	got3 := e3.Error()
+	if strings.Contains(got3, "400 400") {
+		t.Errorf("Error() duplicated status code: %q", got3)
+	}
+	if !strings.Contains(got3, "additionalProperties") {
+		t.Errorf("Error() should include body detail, got %q", got3)
+	}
+}
+
+func TestIsContextOverflow(t *testing.T) {
+	if IsContextOverflow(NewLLMError("sap-vertex", 400, "400 Bad Request", `{"error":"Unknown name additionalProperties"}`)) {
+		t.Error("schema 400 should not be treated as context overflow")
+	}
+	if !IsContextOverflow(NewLLMError("openai", 400, "Bad Request", `{"error":{"code":"context_length_exceeded"}}`)) {
+		t.Error("context_length_exceeded should be treated as overflow")
+	}
+	if IsContextOverflow(NewLLMError("openai", 429, "rate limited", "too many tokens")) {
+		t.Error("non-400 should not be overflow even with keywords")
 	}
 }
 

--- a/pkg/provider/llmerror/max_output.go
+++ b/pkg/provider/llmerror/max_output.go
@@ -1,0 +1,40 @@
+package llmerror
+
+import (
+	"regexp"
+	"strconv"
+)
+
+// Matches Vertex / SAP AI Core messages like:
+//
+//	"Unable to submit request because it has a maxOutputTokens value of 64000
+//	 but the supported range is from 1 (inclusive) to 32769 (exclusive)."
+var maxOutputRangeRe = regexp.MustCompile(
+	`(?i)maxOutputTokens\s+value\s+of\s+(\d+).*?supported\s+range\s+is\s+from\s+(\d+)\s+\((inclusive|exclusive)\)\s+to\s+(\d+)\s+\((inclusive|exclusive)\)`,
+)
+
+// ParseMaxOutputTokensLimit extracts the maximum allowed maxOutputTokens from
+// a provider error body. Returns (max, true) when the body describes a
+// supported range; otherwise (0, false).
+//
+// For an exclusive upper bound B, the allowed max is B-1.
+// For an inclusive upper bound B, the allowed max is B.
+func ParseMaxOutputTokensLimit(body string) (int, bool) {
+	m := maxOutputRangeRe.FindStringSubmatch(body)
+	if m == nil {
+		return 0, false
+	}
+	upper, err := strconv.Atoi(m[4])
+	if err != nil || upper <= 0 {
+		return 0, false
+	}
+	upperKind := m[5]
+	max := upper
+	if upperKind == "exclusive" {
+		max = upper - 1
+	}
+	if max <= 0 {
+		return 0, false
+	}
+	return max, true
+}

--- a/pkg/provider/llmerror/max_output_test.go
+++ b/pkg/provider/llmerror/max_output_test.go
@@ -1,0 +1,35 @@
+package llmerror
+
+import "testing"
+
+func TestParseMaxOutputTokensLimit_ExclusiveRange(t *testing.T) {
+	t.Parallel()
+	body := `{"error":{"code":400,"message":"Unable to submit request because it has a maxOutputTokens value of 64000 but the supported range is from 1 (inclusive) to 32769 (exclusive). Update the value and try again.","status":"INVALID_ARGUMENT"}}`
+	got, ok := ParseMaxOutputTokensLimit(body)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if got != 32768 {
+		t.Errorf("got %d, want 32768", got)
+	}
+}
+
+func TestParseMaxOutputTokensLimit_InclusiveUpper(t *testing.T) {
+	t.Parallel()
+	body := `maxOutputTokens value of 100000 but the supported range is from 1 (inclusive) to 8192 (inclusive)`
+	got, ok := ParseMaxOutputTokensLimit(body)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if got != 8192 {
+		t.Errorf("got %d, want 8192", got)
+	}
+}
+
+func TestParseMaxOutputTokensLimit_Unrelated400(t *testing.T) {
+	t.Parallel()
+	body := `{"error":{"message":"Unknown name \"additionalProperties\" at 'tools'"}}`
+	if _, ok := ParseMaxOutputTokensLimit(body); ok {
+		t.Error("expected parse failure for unrelated 400")
+	}
+}

--- a/pkg/provider/llmerror/no_function_calling.go
+++ b/pkg/provider/llmerror/no_function_calling.go
@@ -1,0 +1,9 @@
+package llmerror
+
+import "strings"
+
+// IsNoFunctionCalling reports whether a provider error body indicates the
+// model rejects function calling / tools (Vertex / SAP AI Core).
+func IsNoFunctionCalling(body string) bool {
+	return strings.Contains(strings.ToLower(body), "does not support function calling")
+}

--- a/pkg/provider/llmerror/no_function_calling_test.go
+++ b/pkg/provider/llmerror/no_function_calling_test.go
@@ -1,0 +1,26 @@
+package llmerror
+
+import "testing"
+
+func TestIsNoFunctionCalling_Match(t *testing.T) {
+	t.Parallel()
+	body := `{"error":{"code":400,"message":"Unable to submit request because the model does not support function calling. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini","status":"INVALID_ARGUMENT"}}`
+	if !IsNoFunctionCalling(body) {
+		t.Fatal("expected match")
+	}
+}
+
+func TestIsNoFunctionCalling_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	if !IsNoFunctionCalling("DOES NOT SUPPORT FUNCTION CALLING") {
+		t.Fatal("expected case-insensitive match")
+	}
+}
+
+func TestIsNoFunctionCalling_Unrelated400(t *testing.T) {
+	t.Parallel()
+	body := `{"error":{"message":"Unknown name \"additionalProperties\" at 'tools'"}}`
+	if IsNoFunctionCalling(body) {
+		t.Error("expected no match for unrelated 400")
+	}
+}

--- a/pkg/provider/sap/model_limits_test.go
+++ b/pkg/provider/sap/model_limits_test.go
@@ -1,0 +1,414 @@
+package sap
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SAP/astonish/pkg/store"
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+)
+
+// memLimits is an in-memory ModelLimitsStore for tests.
+type memLimits struct {
+	mu   sync.Mutex
+	data map[string]store.ModelLimitEntry
+}
+
+func newMemLimits() *memLimits {
+	return &memLimits{data: map[string]store.ModelLimitEntry{}}
+}
+
+func (m *memLimits) Get(_ context.Context, provider, modelName string) (*store.ModelLimitEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e, ok := m.data[store.ModelLimitsKey(provider, modelName)]
+	if !ok {
+		return nil, nil
+	}
+	cp := e
+	return &cp, nil
+}
+
+func (m *memLimits) UpsertMaxOutput(_ context.Context, provider, modelName string, max int, source string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := store.ModelLimitsKey(provider, modelName)
+	if existing, ok := m.data[key]; ok && existing.MaxOutputTokens > 0 && existing.MaxOutputTokens <= max {
+		return nil
+	}
+	e := m.data[key]
+	e.MaxOutputTokens = max
+	e.Source = source
+	e.UpdatedAt = time.Now().UTC()
+	m.data[key] = e
+	return nil
+}
+
+func (m *memLimits) UpsertSupportsTools(_ context.Context, provider, modelName string, supports bool, source string) error {
+	if supports {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := store.ModelLimitsKey(provider, modelName)
+	if existing, ok := m.data[key]; ok && existing.SupportsTools != nil && !*existing.SupportsTools {
+		return nil
+	}
+	e := m.data[key]
+	f := false
+	e.SupportsTools = &f
+	e.Source = source
+	e.UpdatedAt = time.Now().UTC()
+	m.data[key] = e
+	return nil
+}
+
+func TestResolveMaxOutputTokens_LearnedOverridesStatic(t *testing.T) {
+	mem := newMemLimits()
+	SetModelLimitsStore(mem)
+	t.Cleanup(func() { SetModelLimitsStore(nil) })
+
+	if got := resolveMaxOutputTokens(context.Background(), "gemini-image-test-xyz"); got != 64000 {
+		t.Fatalf("fallback: got %d, want 64000", got)
+	}
+
+	_ = mem.UpsertMaxOutput(context.Background(), sapAICoreProviderType, "gemini-image-test-xyz", 32768, "learned_400")
+	if got := resolveMaxOutputTokens(context.Background(), "gemini-image-test-xyz"); got != 32768 {
+		t.Fatalf("learned: got %d, want 32768", got)
+	}
+}
+
+func TestMemLimits_UpsertOnlyDecreases(t *testing.T) {
+	t.Parallel()
+	mem := newMemLimits()
+	ctx := context.Background()
+	_ = mem.UpsertMaxOutput(ctx, "sap_ai_core", "m", 32768, "learned_400")
+	_ = mem.UpsertMaxOutput(ctx, "sap_ai_core", "m", 64000, "learned_400")
+	e, _ := mem.Get(ctx, "sap_ai_core", "m")
+	if e.MaxOutputTokens != 32768 {
+		t.Fatalf("got %d, want 32768 (only-decrease)", e.MaxOutputTokens)
+	}
+	_ = mem.UpsertMaxOutput(ctx, "sap_ai_core", "m", 8192, "learned_400")
+	e, _ = mem.Get(ctx, "sap_ai_core", "m")
+	if e.MaxOutputTokens != 8192 {
+		t.Fatalf("got %d, want 8192 (decrease allowed)", e.MaxOutputTokens)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestGenerateVertexContent_LearnsAndRetries(t *testing.T) {
+	mem := newMemLimits()
+	SetModelLimitsStore(mem)
+	t.Cleanup(func() { SetModelLimitsStore(nil) })
+
+	var calls int
+	var secondMax int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		_ = json.Unmarshal(body, &payload)
+		gen, _ := payload["generationConfig"].(map[string]any)
+		maxF, _ := gen["maxOutputTokens"].(float64)
+
+		if calls == 1 {
+			if int(maxF) != 64000 {
+				t.Errorf("first call maxOutputTokens=%v, want 64000", maxF)
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":400,"message":"Unable to submit request because it has a maxOutputTokens value of 64000 but the supported range is from 1 (inclusive) to 32769 (exclusive).","status":"INVALID_ARGUMENT"}}`))
+			return
+		}
+		secondMax = int(maxF)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`))
+	}))
+	defer srv.Close()
+
+	p := &Provider{
+		httpClient: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return http.DefaultTransport.RoundTrip(req)
+		})},
+		baseURL:      srv.URL + "/v2",
+		deploymentID: "dep1",
+		modelName:    "gemini-image-learn-retry",
+		authConfig:   &sapTransport{resourceGroup: "default"},
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}}},
+	}
+
+	var gotText string
+	var gotErr error
+	for resp, err := range p.generateVertexContent(context.Background(), req, false) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		if resp != nil && resp.Content != nil && len(resp.Content.Parts) > 0 {
+			gotText = resp.Content.Parts[0].Text
+		}
+	}
+	if gotErr != nil {
+		t.Fatalf("unexpected error: %v", gotErr)
+	}
+	if gotText != "ok" {
+		t.Fatalf("got text %q, want ok", gotText)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 HTTP calls (fail+retry), got %d", calls)
+	}
+	if secondMax != 32768 {
+		t.Fatalf("retry maxOutputTokens=%d, want 32768", secondMax)
+	}
+	entry, _ := mem.Get(context.Background(), sapAICoreProviderType, "gemini-image-learn-retry")
+	if entry == nil || entry.MaxOutputTokens != 32768 {
+		t.Fatalf("expected learned 32768 in store, got %+v", entry)
+	}
+}
+
+func TestResolveOmitTools_LearnedFalse(t *testing.T) {
+	mem := newMemLimits()
+	SetModelLimitsStore(mem)
+	t.Cleanup(func() { SetModelLimitsStore(nil) })
+
+	if resolveOmitTools(context.Background(), "gemini-image-no-tools") {
+		t.Fatal("expected omitTools=false when unknown")
+	}
+	_ = mem.UpsertSupportsTools(context.Background(), sapAICoreProviderType, "gemini-image-no-tools", false, "learned_400")
+	if !resolveOmitTools(context.Background(), "gemini-image-no-tools") {
+		t.Fatal("expected omitTools=true after learning false")
+	}
+}
+
+func TestMemLimits_UpsertSupportsToolsOnlyFalse(t *testing.T) {
+	t.Parallel()
+	mem := newMemLimits()
+	ctx := context.Background()
+	_ = mem.UpsertSupportsTools(ctx, "sap_ai_core", "m", true, "learned_400")
+	e, _ := mem.Get(ctx, "sap_ai_core", "m")
+	if e != nil {
+		t.Fatalf("expected no entry when upserting true, got %+v", e)
+	}
+	_ = mem.UpsertSupportsTools(ctx, "sap_ai_core", "m", false, "learned_400")
+	e, _ = mem.Get(ctx, "sap_ai_core", "m")
+	if e == nil || e.SupportsTools == nil || *e.SupportsTools {
+		t.Fatalf("expected supports_tools=false, got %+v", e)
+	}
+	// Coexist with max output on same entry.
+	_ = mem.UpsertMaxOutput(ctx, "sap_ai_core", "m", 32768, "learned_400")
+	e, _ = mem.Get(ctx, "sap_ai_core", "m")
+	if e.MaxOutputTokens != 32768 || e.SupportsTools == nil || *e.SupportsTools {
+		t.Fatalf("expected both fields, got %+v", e)
+	}
+}
+
+func TestGenerateVertexContent_LearnsNoToolsAndRetries(t *testing.T) {
+	mem := newMemLimits()
+	SetModelLimitsStore(mem)
+	t.Cleanup(func() { SetModelLimitsStore(nil) })
+
+	var calls int
+	var secondHadTools bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		_ = json.Unmarshal(body, &payload)
+		_, hasTools := payload["tools"]
+		_, hasToolConfig := payload["toolConfig"]
+
+		if calls == 1 {
+			if !hasTools && !hasToolConfig {
+				t.Error("first call expected tools or toolConfig")
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":400,"message":"Unable to submit request because the model does not support function calling. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini","status":"INVALID_ARGUMENT"}}`))
+			return
+		}
+		secondHadTools = hasTools || hasToolConfig
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`))
+	}))
+	defer srv.Close()
+
+	p := &Provider{
+		httpClient:   srv.Client(),
+		baseURL:      srv.URL + "/v2",
+		deploymentID: "dep1",
+		modelName:    "gemini-image-no-fc",
+		authConfig:   &sapTransport{resourceGroup: "default"},
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}}},
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{{
+					Name:        "read_file",
+					Description: "read a file",
+				}},
+			}},
+		},
+	}
+
+	var gotText string
+	var gotErr error
+	for resp, err := range p.generateVertexContent(context.Background(), req, false) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		if resp != nil && resp.Content != nil && len(resp.Content.Parts) > 0 {
+			gotText = resp.Content.Parts[0].Text
+		}
+	}
+	if gotErr != nil {
+		t.Fatalf("unexpected error: %v", gotErr)
+	}
+	if gotText != "ok" {
+		t.Fatalf("got text %q, want ok", gotText)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 HTTP calls (fail+retry), got %d", calls)
+	}
+	if secondHadTools {
+		t.Fatal("retry request still included tools/toolConfig")
+	}
+	entry, _ := mem.Get(context.Background(), sapAICoreProviderType, "gemini-image-no-fc")
+	if entry == nil || entry.SupportsTools == nil || *entry.SupportsTools {
+		t.Fatalf("expected learned supports_tools=false, got %+v", entry)
+	}
+}
+
+func TestListModelsWithMetadata_UsesLearnedMax(t *testing.T) {
+	// Reset cache
+	sapModelCacheMu.Lock()
+	sapModelCache = nil
+	sapModelCacheTime = time.Time{}
+	sapModelCacheMu.Unlock()
+
+	mem := newMemLimits()
+	SetModelLimitsStore(mem)
+	t.Cleanup(func() {
+		SetModelLimitsStore(nil)
+		sapModelCacheMu.Lock()
+		sapModelCache = nil
+		sapModelCacheTime = time.Time{}
+		sapModelCacheMu.Unlock()
+	})
+	_ = mem.UpsertMaxOutput(context.Background(), sapAICoreProviderType, "gemini-image-meta", 32768, "learned_400")
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "tok", "expires_in": 3600})
+	}))
+	defer tokenSrv.Close()
+
+	deploySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resources": []map[string]any{
+				{
+					"status": "RUNNING",
+					"details": map[string]any{
+						"resources": map[string]any{
+							"backendDetails": map[string]any{
+								"model": map[string]any{"name": "gemini-image-meta"},
+							},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer deploySrv.Close()
+
+	models, err := ListModelsWithMetadata(
+		context.Background(),
+		"id", "secret",
+		tokenSrv.URL,
+		deploySrv.URL,
+		"default",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].MaxOutputTokens != 32768 {
+		t.Errorf("MaxOutputTokens=%d, want learned 32768", models[0].MaxOutputTokens)
+	}
+}
+
+func TestListModelsWithMetadata_UsesLearnedSupportsTools(t *testing.T) {
+	sapModelCacheMu.Lock()
+	sapModelCache = nil
+	sapModelCacheTime = time.Time{}
+	sapModelCacheMu.Unlock()
+
+	mem := newMemLimits()
+	SetModelLimitsStore(mem)
+	t.Cleanup(func() {
+		SetModelLimitsStore(nil)
+		sapModelCacheMu.Lock()
+		sapModelCache = nil
+		sapModelCacheTime = time.Time{}
+		sapModelCacheMu.Unlock()
+	})
+	_ = mem.UpsertSupportsTools(context.Background(), sapAICoreProviderType, "gemini-image-meta-tools", false, "learned_400")
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "tok", "expires_in": 3600})
+	}))
+	defer tokenSrv.Close()
+
+	deploySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resources": []map[string]any{
+				{
+					"status": "RUNNING",
+					"details": map[string]any{
+						"resources": map[string]any{
+							"backendDetails": map[string]any{
+								"model": map[string]any{"name": "gemini-image-meta-tools"},
+							},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer deploySrv.Close()
+
+	models, err := ListModelsWithMetadata(
+		context.Background(),
+		"id", "secret",
+		tokenSrv.URL,
+		deploySrv.URL,
+		"default",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].SupportsTools == nil || *models[0].SupportsTools {
+		t.Errorf("SupportsTools=%v, want false", models[0].SupportsTools)
+	}
+}

--- a/pkg/provider/sap/sap.go
+++ b/pkg/provider/sap/sap.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -21,8 +22,82 @@ import (
 	"github.com/SAP/astonish/pkg/provider/llmerror"
 	"github.com/SAP/astonish/pkg/provider/openai"
 	"github.com/SAP/astonish/pkg/provider/vertex"
+	"github.com/SAP/astonish/pkg/store"
 	"google.golang.org/adk/model"
 )
+
+const sapAICoreProviderType = "sap_ai_core"
+
+// modelLimitsStore is the optional durable store for learned per-model token
+// limits (e.g. maxOutputTokens from Vertex 400 responses). Set at daemon boot.
+var (
+	modelLimitsStore   store.ModelLimitsStore
+	modelLimitsStoreMu sync.RWMutex
+)
+
+// SetModelLimitsStore registers the platform store used to persist learned
+// model token limits. Nil clears the store (tests / miswired daemon).
+func SetModelLimitsStore(s store.ModelLimitsStore) {
+	modelLimitsStoreMu.Lock()
+	defer modelLimitsStoreMu.Unlock()
+	modelLimitsStore = s
+}
+
+func getModelLimitsStore() store.ModelLimitsStore {
+	modelLimitsStoreMu.RLock()
+	defer modelLimitsStoreMu.RUnlock()
+	return modelLimitsStore
+}
+
+// resolveMaxOutputTokens returns the effective maxOutputTokens for a model:
+// learned override if present, otherwise GetModelConfig static/fallback.
+func resolveMaxOutputTokens(ctx context.Context, modelName string) int {
+	cfg := GetModelConfig(modelName)
+	maxTokens := cfg.MaxTokens
+	if s := getModelLimitsStore(); s != nil {
+		if entry, err := s.Get(ctx, sapAICoreProviderType, modelName); err == nil && entry != nil && entry.MaxOutputTokens > 0 {
+			return entry.MaxOutputTokens
+		}
+	}
+	return maxTokens
+}
+
+// resolveOmitTools reports whether tools/toolConfig should be stripped from
+// Vertex requests for this model (learned SupportsTools == false).
+func resolveOmitTools(ctx context.Context, modelName string) bool {
+	if s := getModelLimitsStore(); s != nil {
+		if entry, err := s.Get(ctx, sapAICoreProviderType, modelName); err == nil && entry != nil &&
+			entry.SupportsTools != nil && !*entry.SupportsTools {
+			return true
+		}
+	}
+	return false
+}
+
+// requestWithoutTools returns a shallow copy of req with Tools and ToolConfig
+// cleared on Config. Contents and other fields are shared.
+func requestWithoutTools(req *model.LLMRequest) *model.LLMRequest {
+	if req == nil {
+		return nil
+	}
+	cp := *req
+	if req.Config != nil {
+		cfg := *req.Config
+		cfg.Tools = nil
+		cfg.ToolConfig = nil
+		cp.Config = &cfg
+	}
+	return &cp
+}
+
+// invalidateModelCache clears the in-memory ListModelsWithMetadata cache so
+// the next UI fetch picks up newly learned limits.
+func invalidateModelCache() {
+	sapModelCacheMu.Lock()
+	sapModelCache = nil
+	sapModelCacheTime = time.Time{}
+	sapModelCacheMu.Unlock()
+}
 
 // Provider implements the model.LLM interface for SAP AI Core.
 type Provider struct {
@@ -515,6 +590,7 @@ type ModelInfo struct {
 	Name            string `json:"name"`
 	ContextLength   int    `json:"context_length,omitempty"`
 	MaxOutputTokens int    `json:"max_completion_tokens,omitempty"`
+	SupportsTools   *bool  `json:"supports_tools,omitempty"`
 }
 
 // Model cache for SAP AI Core
@@ -543,15 +619,30 @@ func ListModelsWithMetadata(ctx context.Context, clientID, clientSecret, authURL
 		return nil, err
 	}
 
-	// Enrich with ModelConfigs metadata
+	// Enrich with ModelConfigs metadata; learned limits override MaxOutputTokens
+	// and SupportsTools when known.
 	var models []ModelInfo
+	limits := getModelLimitsStore()
 	for _, id := range modelIDs {
 		config := GetModelConfig(id)
+		maxOut := config.MaxTokens
+		var supportsTools *bool
+		if limits != nil {
+			if entry, err := limits.Get(ctx, sapAICoreProviderType, id); err == nil && entry != nil {
+				if entry.MaxOutputTokens > 0 {
+					maxOut = entry.MaxOutputTokens
+				}
+				if entry.SupportsTools != nil {
+					supportsTools = entry.SupportsTools
+				}
+			}
+		}
 		models = append(models, ModelInfo{
 			ID:              id,
 			Name:            id,
 			ContextLength:   config.ContextWindow,
-			MaxOutputTokens: config.MaxTokens,
+			MaxOutputTokens: maxOut,
+			SupportsTools:   supportsTools,
 		})
 	}
 
@@ -639,75 +730,134 @@ func (p *Provider) generateBedrockContent(ctx context.Context, req *model.LLMReq
 
 func (p *Provider) generateVertexContent(ctx context.Context, req *model.LLMRequest, streaming bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		// Get model-specific config
-		config := GetModelConfig(p.modelName)
+		maxTokens := resolveMaxOutputTokens(ctx, p.modelName)
+		omitTools := resolveOmitTools(ctx, p.modelName)
+		retriedMaxOut := false
+		retriedNoTools := false
 
-		// Convert request using vertex protocol with model-specific maxOutputTokens
-		vertexReq, err := vertex.ConvertRequest(req, config.MaxTokens)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-
-		payload, err := json.Marshal(vertexReq)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-
-		var url string
-		if streaming {
-			// Vertex AI streaming endpoint: /models/{model}:streamGenerateContent?alt=sse
-			url = fmt.Sprintf("%s/inference/deployments/%s/models/%s:streamGenerateContent?alt=sse", p.baseURL, p.deploymentID, p.modelName)
-		} else {
-			// Vertex AI non-streaming endpoint: /models/{model}:generateContent
-			url = fmt.Sprintf("%s/inference/deployments/%s/models/%s:generateContent", p.baseURL, p.deploymentID, p.modelName)
-		}
-
-		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("AI-Resource-Group", p.authConfig.resourceGroup)
-		// Token is added by transport
-
-		resp, err := p.httpClient.Do(httpReq)
-		if err != nil {
-			yield(nil, err)
-			return
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			body, readErr := io.ReadAll(resp.Body)
-			if readErr != nil {
-				body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
-			}
-			yield(nil, llmerror.NewFromResponse("sap-vertex", resp, body))
-			return
-		}
-
-		if streaming {
-			// Handle streaming response using vertex protocol
-			for resp, err := range vertex.ParseStream(resp.Body) {
-				if !yield(resp, err) {
-					return
-				}
-			}
-		} else {
-			// Non-streaming response
-			body, readErr := io.ReadAll(resp.Body)
-			if readErr != nil {
-				body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
-			}
-			llmResp, err := vertex.ParseResponse(body)
+		for {
+			resp, body, err := p.doVertexRequest(ctx, req, streaming, maxTokens, omitTools)
 			if err != nil {
 				yield(nil, err)
 				return
 			}
-			yield(llmResp, nil)
+
+			if resp.StatusCode == http.StatusOK {
+				if streaming {
+					for llmResp, parseErr := range vertex.ParseStream(resp.Body) {
+						if !yield(llmResp, parseErr) {
+							resp.Body.Close()
+							return
+						}
+					}
+					resp.Body.Close()
+					return
+				}
+				llmResp, parseErr := vertex.ParseResponse(body)
+				resp.Body.Close()
+				if parseErr != nil {
+					yield(nil, parseErr)
+					return
+				}
+				yield(llmResp, nil)
+				return
+			}
+
+			resp.Body.Close()
+			llmErr := llmerror.NewFromResponse("sap-vertex", resp, body)
+			bodyStr := string(body)
+
+			if resp.StatusCode == http.StatusBadRequest {
+				// Learn maxOutputTokens from the error and retry once.
+				if !retriedMaxOut {
+					if learned, ok := llmerror.ParseMaxOutputTokensLimit(bodyStr); ok && learned > 0 && learned < maxTokens {
+						if s := getModelLimitsStore(); s != nil {
+							if upsertErr := s.UpsertMaxOutput(ctx, sapAICoreProviderType, p.modelName, learned, "learned_400"); upsertErr != nil {
+								slog.Warn("failed to persist learned maxOutputTokens",
+									"component", "sap-vertex", "model", p.modelName, "max", learned, "error", upsertErr)
+							} else {
+								invalidateModelCache()
+								slog.Info("learned maxOutputTokens from provider 400",
+									"component", "sap-vertex", "model", p.modelName, "max", learned)
+							}
+						}
+						maxTokens = learned
+						retriedMaxOut = true
+						continue
+					}
+				}
+
+				// Learn that the model rejects function calling and retry once without tools.
+				if !retriedNoTools && !omitTools && llmerror.IsNoFunctionCalling(bodyStr) && requestHasTools(req) {
+					if s := getModelLimitsStore(); s != nil {
+						if upsertErr := s.UpsertSupportsTools(ctx, sapAICoreProviderType, p.modelName, false, "learned_400"); upsertErr != nil {
+							slog.Warn("failed to persist learned supports_tools=false",
+								"component", "sap-vertex", "model", p.modelName, "error", upsertErr)
+						} else {
+							invalidateModelCache()
+							slog.Info("learned model does not support function calling",
+								"component", "sap-vertex", "model", p.modelName)
+						}
+					}
+					omitTools = true
+					retriedNoTools = true
+					continue
+				}
+			}
+
+			yield(nil, llmErr)
+			return
 		}
 	}
+}
+
+func requestHasTools(req *model.LLMRequest) bool {
+	return req != nil && req.Config != nil && (len(req.Config.Tools) > 0 || req.Config.ToolConfig != nil)
+}
+
+// doVertexRequest builds and executes one Vertex generateContent call.
+// On HTTP 200 with streaming, the caller owns resp.Body.
+// On HTTP 200 with non-streaming (or any error status), body is fully read
+// and resp.Body is still open for the caller to Close.
+func (p *Provider) doVertexRequest(ctx context.Context, req *model.LLMRequest, streaming bool, maxTokens int, omitTools bool) (*http.Response, []byte, error) {
+	if omitTools {
+		req = requestWithoutTools(req)
+	}
+	vertexReq, err := vertex.ConvertRequest(req, maxTokens)
+	if err != nil {
+		return nil, nil, err
+	}
+	payload, err := json.Marshal(vertexReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var url string
+	if streaming {
+		url = fmt.Sprintf("%s/inference/deployments/%s/models/%s:streamGenerateContent?alt=sse", p.baseURL, p.deploymentID, p.modelName)
+	} else {
+		url = fmt.Sprintf("%s/inference/deployments/%s/models/%s:generateContent", p.baseURL, p.deploymentID, p.modelName)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("AI-Resource-Group", p.authConfig.resourceGroup)
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if resp.StatusCode == http.StatusOK && streaming {
+		return resp, nil, nil
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		body = []byte(fmt.Sprintf("<unreadable: %v>", readErr))
+	}
+	return resp, body, nil
 }

--- a/pkg/provider/vertex/protocol.go
+++ b/pkg/provider/vertex/protocol.go
@@ -127,7 +127,14 @@ func ConvertRequest(req *model.LLMRequest, maxOutputTokens int) (*Request, error
 					Response: p.FunctionResponse.Response,
 				}
 			}
+			// Skip empty parts — Vertex/Gemini 400s on `{}` parts.
+			if part.Text == "" && part.InlineData == nil && part.FunctionCall == nil && part.FunctionResponse == nil {
+				continue
+			}
 			parts = append(parts, part)
+		}
+		if len(parts) == 0 {
+			continue
 		}
 		vertexReq.Contents = append(vertexReq.Contents, Content{
 			Role:  c.Role,
@@ -139,10 +146,15 @@ func ConvertRequest(req *model.LLMRequest, maxOutputTokens int) (*Request, error
 	if req.Config != nil && req.Config.SystemInstruction != nil {
 		parts := make([]Part, 0)
 		for _, p := range req.Config.SystemInstruction.Parts {
+			if p.Text == "" {
+				continue
+			}
 			parts = append(parts, Part{Text: p.Text})
 		}
-		vertexReq.SystemInstruction = &Content{
-			Parts: parts,
+		if len(parts) > 0 {
+			vertexReq.SystemInstruction = &Content{
+				Parts: parts,
+			}
 		}
 	}
 
@@ -151,31 +163,15 @@ func ConvertRequest(req *model.LLMRequest, maxOutputTokens int) (*Request, error
 		for _, t := range req.Config.Tools {
 			fds := make([]FunctionDeclaration, 0)
 			for _, fd := range t.FunctionDeclarations {
-				// Sanitize parameters schema - Vertex AI rejects $schema
-				params := fd.ParametersJsonSchema
-
-				// Ensure params is a map so we can sanitize it
-				// The schema can be various types (struct, map, etc.) from ADK
-				schemaBytes, err := json.Marshal(params)
-				if err == nil {
-					var paramsMap map[string]interface{}
-					if err := json.Unmarshal(schemaBytes, &paramsMap); err == nil {
-						// Create a copy to avoid modifying the original
-						newParams := make(map[string]interface{})
-						for k, v := range paramsMap {
-							if k != "$schema" && k != "additionalProperties" {
-								newParams[k] = v
-							}
-						}
-						params = newParams
-					}
-				}
-
+				params := sanitizeToolParameters(fd)
 				fds = append(fds, FunctionDeclaration{
 					Name:        fd.Name,
 					Description: fd.Description,
 					Parameters:  params,
 				})
+			}
+			if len(fds) == 0 {
+				continue
 			}
 			vertexReq.Tools = append(vertexReq.Tools, Tool{
 				FunctionDeclarations: fds,
@@ -198,6 +194,115 @@ func ConvertRequest(req *model.LLMRequest, maxOutputTokens int) (*Request, error
 	}
 
 	return vertexReq, nil
+}
+
+// sanitizeToolParameters converts an ADK function declaration's parameter
+// schema into a Vertex/Gemini-compatible JSON Schema. Gemini's REST API
+// rejects several JSON Schema keywords that ADK/jsonschema-go emit
+// (notably nested additionalProperties and $schema).
+func sanitizeToolParameters(fd *genai.FunctionDeclaration) any {
+	raw := fd.ParametersJsonSchema
+	if raw == nil && fd.Parameters != nil {
+		raw = fd.Parameters
+	}
+	if raw == nil {
+		return map[string]any{"type": "object", "properties": map[string]any{}}
+	}
+
+	schemaBytes, err := json.Marshal(raw)
+	if err != nil {
+		return raw
+	}
+	var paramsMap map[string]any
+	if err := json.Unmarshal(schemaBytes, &paramsMap); err != nil {
+		return raw
+	}
+	sanitizeSchema(paramsMap)
+	if len(paramsMap) == 0 {
+		return map[string]any{"type": "object", "properties": map[string]any{}}
+	}
+	return paramsMap
+}
+
+// unsupportedSchemaKeys are JSON Schema keywords Gemini/Vertex reject in
+// functionDeclarations.parameters (and nested object schemas).
+var unsupportedSchemaKeys = map[string]bool{
+	"$schema":               true,
+	"$id":                   true,
+	"$defs":                 true,
+	"$ref":                  true,
+	"definitions":           true,
+	"additionalProperties":  true,
+	"unevaluatedProperties": true,
+	"patternProperties":     true,
+}
+
+// sanitizeSchema recursively strips Gemini-unsupported JSON Schema keywords
+// and normalizes nullable type unions produced by jsonschema-go for pointer
+// fields (e.g. ["null","integer"] → "integer").
+func sanitizeSchema(schema map[string]any) {
+	for k := range unsupportedSchemaKeys {
+		delete(schema, k)
+	}
+
+	if t, ok := schema["type"]; ok {
+		schema["type"] = normalizeSchemaType(t)
+	}
+
+	if props, ok := schema["properties"].(map[string]any); ok {
+		for _, prop := range props {
+			if propMap, ok := prop.(map[string]any); ok {
+				sanitizeSchema(propMap)
+			}
+		}
+	}
+
+	switch items := schema["items"].(type) {
+	case map[string]any:
+		sanitizeSchema(items)
+	case []any:
+		for _, item := range items {
+			if itemMap, ok := item.(map[string]any); ok {
+				sanitizeSchema(itemMap)
+			}
+		}
+	}
+
+	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
+		if arr, ok := schema[key].([]any); ok {
+			for _, item := range arr {
+				if itemMap, ok := item.(map[string]any); ok {
+					sanitizeSchema(itemMap)
+				}
+			}
+		}
+	}
+}
+
+// normalizeSchemaType converts JSON Schema type unions that include null
+// (from Go pointer fields) into a single non-null type. Gemini rejects
+// type arrays in function parameter schemas.
+func normalizeSchemaType(t any) any {
+	arr, ok := t.([]any)
+	if !ok {
+		return t
+	}
+	var nonNull any
+	for _, v := range arr {
+		s, ok := v.(string)
+		if !ok || s == "null" {
+			continue
+		}
+		if nonNull != nil {
+			// Multiple non-null types — keep the original union.
+			return t
+		}
+		nonNull = s
+	}
+	if nonNull != nil {
+		return nonNull
+	}
+	return t
 }
 
 // ParseResponse converts a Vertex AI Response body to an ADK LLMResponse.

--- a/pkg/provider/vertex/protocol.go
+++ b/pkg/provider/vertex/protocol.go
@@ -305,6 +305,38 @@ func normalizeSchemaType(t any) any {
 	return t
 }
 
+// mapPart converts a Vertex Part into a genai.Part. Returns nil when the part
+// has no usable fields (empty after dropping unknown content).
+func mapPart(p Part) *genai.Part {
+	part := &genai.Part{}
+	if p.Text != "" {
+		part.Text = p.Text
+	}
+	if p.FunctionCall != nil {
+		part.FunctionCall = &genai.FunctionCall{
+			Name: p.FunctionCall.Name,
+			Args: p.FunctionCall.Args,
+		}
+	}
+	if p.InlineData != nil && p.InlineData.Data != "" {
+		raw, err := base64.StdEncoding.DecodeString(p.InlineData.Data)
+		if err != nil {
+			// Some providers omit padding; try raw encoding as a fallback.
+			raw, err = base64.RawStdEncoding.DecodeString(p.InlineData.Data)
+		}
+		if err == nil && len(raw) > 0 {
+			part.InlineData = &genai.Blob{
+				MIMEType: p.InlineData.MimeType,
+				Data:     raw,
+			}
+		}
+	}
+	if part.Text == "" && part.FunctionCall == nil && part.InlineData == nil {
+		return nil
+	}
+	return part
+}
+
 // ParseResponse converts a Vertex AI Response body to an ADK LLMResponse.
 func ParseResponse(body []byte) (*model.LLMResponse, error) {
 	var vertexResp Response
@@ -323,17 +355,9 @@ func ParseResponse(body []byte) (*model.LLMResponse, error) {
 
 	var parts []*genai.Part
 	for _, p := range candidate.Content.Parts {
-		part := &genai.Part{}
-		if p.Text != "" {
-			part.Text = p.Text
+		if part := mapPart(p); part != nil {
+			parts = append(parts, part)
 		}
-		if p.FunctionCall != nil {
-			part.FunctionCall = &genai.FunctionCall{
-				Name: p.FunctionCall.Name,
-				Args: p.FunctionCall.Args,
-			}
-		}
-		parts = append(parts, part)
 	}
 
 	return &model.LLMResponse{
@@ -386,18 +410,20 @@ func ParseStream(reader io.Reader) iter.Seq2[*model.LLMResponse, error] {
 						var parts []*genai.Part
 						hasText := false
 						hasFunctionCall := false
+						hasInlineData := false
 						for _, p := range candidate.Content.Parts {
-							part := &genai.Part{}
-							if p.Text != "" {
-								part.Text = p.Text
+							part := mapPart(p)
+							if part == nil {
+								continue
+							}
+							if part.Text != "" {
 								hasText = true
 							}
-							if p.FunctionCall != nil {
-								part.FunctionCall = &genai.FunctionCall{
-									Name: p.FunctionCall.Name,
-									Args: p.FunctionCall.Args,
-								}
+							if part.FunctionCall != nil {
 								hasFunctionCall = true
+							}
+							if part.InlineData != nil {
+								hasInlineData = true
 							}
 							parts = append(parts, part)
 						}
@@ -410,7 +436,7 @@ func ParseStream(reader io.Reader) iter.Seq2[*model.LLMResponse, error] {
 								},
 							}
 
-							if hasText && !hasFunctionCall {
+							if hasText && !hasFunctionCall && !hasInlineData {
 								// Pure text chunk — accumulate and mark partial
 								for _, p := range parts {
 									if p.Text != "" {
@@ -418,8 +444,8 @@ func ParseStream(reader io.Reader) iter.Seq2[*model.LLMResponse, error] {
 									}
 								}
 								resp.Partial = true
-							} else if hasFunctionCall && textAccum.Len() > 0 {
-								// Function call after text — emit aggregated text first
+							} else if (hasFunctionCall || hasInlineData) && textAccum.Len() > 0 {
+								// Non-text content after text — emit aggregated text first
 								if !yield(&model.LLMResponse{
 									Content: &genai.Content{
 										Role:  candidate.Content.Role,

--- a/pkg/provider/vertex/protocol_test.go
+++ b/pkg/provider/vertex/protocol_test.go
@@ -1,7 +1,10 @@
 package vertex
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -363,6 +366,57 @@ func TestParseResponse_FunctionCall(t *testing.T) {
 	}
 }
 
+func TestParseResponse_InlineData(t *testing.T) {
+	t.Parallel()
+	pngBytes := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+	body := fmt.Sprintf(`{
+		"candidates": [{
+			"content": {
+				"role": "model",
+				"parts": [{"inlineData": {"mimeType": "image/png", "data": %q}}]
+			}
+		}]
+	}`, b64)
+
+	resp, err := ParseResponse([]byte(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Content == nil || len(resp.Content.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %+v", resp.Content)
+	}
+	id := resp.Content.Parts[0].InlineData
+	if id == nil {
+		t.Fatal("expected InlineData")
+	}
+	if id.MIMEType != "image/png" {
+		t.Errorf("MIMEType=%q, want image/png", id.MIMEType)
+	}
+	if !bytes.Equal(id.Data, pngBytes) {
+		t.Errorf("data mismatch: got %v", id.Data)
+	}
+}
+
+func TestParseResponse_SkipsEmptyParts(t *testing.T) {
+	t.Parallel()
+	body := `{
+		"candidates": [{
+			"content": {
+				"role": "model",
+				"parts": [{}, {"text": "hi"}]
+			}
+		}]
+	}`
+	resp, err := ParseResponse([]byte(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Content.Parts) != 1 || resp.Content.Parts[0].Text != "hi" {
+		t.Fatalf("expected only text part, got %+v", resp.Content.Parts)
+	}
+}
+
 func TestParseResponse_EmptyCandidates(t *testing.T) {
 	t.Parallel()
 	body := `{"candidates": []}`
@@ -495,6 +549,35 @@ data: {"candidates":[{"content":{"role":"model","parts":[{"text":"!"}]}}]}
 	}
 	if responses[3].Content.Parts[0].Text != "Hello World!" {
 		t.Errorf("expected 'Hello World!', got %q", responses[3].Content.Parts[0].Text)
+	}
+}
+
+func TestParseStream_InlineDataOnly(t *testing.T) {
+	t.Parallel()
+	pngBytes := []byte{0x89, 0x50, 0x4e, 0x47}
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+	input := fmt.Sprintf("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"inlineData\":{\"mimeType\":\"image/png\",\"data\":%q}}]}}]}\n\n", b64)
+	reader := strings.NewReader(input)
+
+	var responses []*model.LLMResponse
+	for resp, err := range ParseStream(reader) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		responses = append(responses, resp)
+	}
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response for image-only chunk, got %d", len(responses))
+	}
+	if responses[0].Partial {
+		t.Error("image-only response should not be Partial")
+	}
+	if responses[0].Content == nil || len(responses[0].Content.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %+v", responses[0].Content)
+	}
+	id := responses[0].Content.Parts[0].InlineData
+	if id == nil || !bytes.Equal(id.Data, pngBytes) {
+		t.Fatalf("expected inline image bytes, got %+v", id)
 	}
 }
 

--- a/pkg/provider/vertex/sanitize_test.go
+++ b/pkg/provider/vertex/sanitize_test.go
@@ -1,0 +1,102 @@
+package vertex
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+)
+
+func TestConvertRequest_NestedAdditionalPropertiesStripped(t *testing.T) {
+	t.Parallel()
+	// Shape mirrors github.com/google/jsonschema-go output for nested objects /
+	// maps / pointer fields used by ADK functiontool schemas.
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path": map[string]any{"type": "string"},
+			"offset": map[string]any{
+				"type": []any{"null", "integer"},
+			},
+			"opts": map[string]any{
+				"type":                 "object",
+				"additionalProperties": true,
+			},
+			"items": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name":  map[string]any{"type": "string"},
+						"value": map[string]any{"type": "integer"},
+					},
+					"additionalProperties": false,
+					"required":             []any{"name", "value"},
+				},
+			},
+		},
+		"required":             []any{"path"},
+		"additionalProperties": false,
+		"$schema":              "https://json-schema.org/draft/2020-12/schema",
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}}},
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{{
+					Name:                 "demo_tool",
+					Description:          "demo",
+					ParametersJsonSchema: schema,
+				}},
+			}},
+		},
+	}
+	vReq, err := ConvertRequest(req, 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := json.Marshal(vReq.Tools[0].FunctionDeclarations[0].Parameters)
+	s := string(b)
+	if strings.Contains(s, "additionalProperties") {
+		t.Errorf("nested additionalProperties still present: %s", s)
+	}
+	if strings.Contains(s, "$schema") {
+		t.Errorf("$schema still present: %s", s)
+	}
+	if strings.Contains(s, `"type":["null","integer"]`) || strings.Contains(s, `"type": ["null", "integer"]`) {
+		t.Errorf("nullable type union not normalized: %s", s)
+	}
+	if !strings.Contains(s, `"type":"integer"`) && !strings.Contains(s, `"type": "integer"`) {
+		t.Errorf("expected offset type normalized to integer, got: %s", s)
+	}
+}
+
+func TestConvertRequest_SkipsEmptyParts(t *testing.T) {
+	t.Parallel()
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{Text: ""},
+				{Text: "Hi"},
+				{},
+			},
+		}},
+	}
+	vReq, err := ConvertRequest(req, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vReq.Contents) != 1 {
+		t.Fatalf("expected 1 content, got %d", len(vReq.Contents))
+	}
+	if len(vReq.Contents[0].Parts) != 1 {
+		t.Fatalf("expected 1 non-empty part, got %d", len(vReq.Contents[0].Parts))
+	}
+	if vReq.Contents[0].Parts[0].Text != "Hi" {
+		t.Errorf("expected Hi, got %q", vReq.Contents[0].Parts[0].Text)
+	}
+}

--- a/pkg/store/entstore/model_limits.go
+++ b/pkg/store/entstore/model_limits.go
@@ -1,0 +1,151 @@
+package entstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	platforment "github.com/SAP/astonish/ent/platform"
+	"github.com/SAP/astonish/pkg/store"
+)
+
+const modelLimitsKey = "model_limits"
+
+// modelLimitsStore implements store.ModelLimitsStore using platform_settings.
+type modelLimitsStore struct {
+	client *platforment.Client
+	mu     sync.Mutex
+}
+
+// ModelLimits returns the platform-scoped model limits store.
+func (s *Store) ModelLimits() store.ModelLimitsStore {
+	return &modelLimitsStore{client: s.platformClient}
+}
+
+func (m *modelLimitsStore) Get(ctx context.Context, provider, model string) (*store.ModelLimitEntry, error) {
+	all, err := m.loadAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := all[store.ModelLimitsKey(provider, model)]
+	if !ok {
+		return nil, nil
+	}
+	cp := entry
+	return &cp, nil
+}
+
+func (m *modelLimitsStore) UpsertMaxOutput(ctx context.Context, provider, model string, max int, source string) error {
+	if max <= 0 {
+		return fmt.Errorf("max output tokens must be positive")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	all, err := m.loadAll(ctx)
+	if err != nil {
+		return err
+	}
+	key := store.ModelLimitsKey(provider, model)
+	if existing, ok := all[key]; ok && existing.MaxOutputTokens > 0 && existing.MaxOutputTokens <= max {
+		// Already at or below the learned cap — do not raise.
+		return nil
+	}
+	entry := all[key]
+	entry.MaxOutputTokens = max
+	if source != "" {
+		entry.Source = source
+	} else {
+		entry.Source = "learned_400"
+	}
+	entry.UpdatedAt = time.Now().UTC()
+	all[key] = entry
+	return m.saveAll(ctx, all)
+}
+
+func (m *modelLimitsStore) UpsertSupportsTools(ctx context.Context, provider, model string, supports bool, source string) error {
+	// We only learn the negative from provider errors.
+	if supports {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	all, err := m.loadAll(ctx)
+	if err != nil {
+		return err
+	}
+	key := store.ModelLimitsKey(provider, model)
+	if existing, ok := all[key]; ok && existing.SupportsTools != nil && !*existing.SupportsTools {
+		// Already learned false — keep it.
+		return nil
+	}
+	entry := all[key]
+	f := false
+	entry.SupportsTools = &f
+	if source != "" {
+		entry.Source = source
+	} else {
+		entry.Source = "learned_400"
+	}
+	entry.UpdatedAt = time.Now().UTC()
+	all[key] = entry
+	return m.saveAll(ctx, all)
+}
+
+func (m *modelLimitsStore) loadAll(ctx context.Context) (map[string]store.ModelLimitEntry, error) {
+	row, err := m.client.PlatformSetting.Get(ctx, modelLimitsKey)
+	if err != nil {
+		if platforment.IsNotFound(err) {
+			return map[string]store.ModelLimitEntry{}, nil
+		}
+		return nil, fmt.Errorf("get model_limits: %w", err)
+	}
+	data, err := json.Marshal(row.Value)
+	if err != nil {
+		return nil, fmt.Errorf("marshal model_limits value: %w", err)
+	}
+	var all map[string]store.ModelLimitEntry
+	if err := json.Unmarshal(data, &all); err != nil {
+		return nil, fmt.Errorf("unmarshal model_limits: %w", err)
+	}
+	if all == nil {
+		all = map[string]store.ModelLimitEntry{}
+	}
+	return all, nil
+}
+
+func (m *modelLimitsStore) saveAll(ctx context.Context, all map[string]store.ModelLimitEntry) error {
+	data, err := json.Marshal(all)
+	if err != nil {
+		return fmt.Errorf("marshal model_limits: %w", err)
+	}
+	var valueMap map[string]any
+	if err := json.Unmarshal(data, &valueMap); err != nil {
+		return fmt.Errorf("unmarshal model_limits to map: %w", err)
+	}
+
+	row, err := m.client.PlatformSetting.Get(ctx, modelLimitsKey)
+	if err != nil {
+		if platforment.IsNotFound(err) {
+			_, err = m.client.PlatformSetting.Create().
+				SetID(modelLimitsKey).
+				SetValue(valueMap).
+				Save(ctx)
+			if err != nil {
+				return fmt.Errorf("create model_limits: %w", err)
+			}
+			return nil
+		}
+		return fmt.Errorf("get model_limits for upsert: %w", err)
+	}
+	_, err = row.Update().SetValue(valueMap).Save(ctx)
+	if err != nil {
+		return fmt.Errorf("update model_limits: %w", err)
+	}
+	return nil
+}
+
+var _ store.ModelLimitsStore = (*modelLimitsStore)(nil)

--- a/pkg/store/model_limits.go
+++ b/pkg/store/model_limits.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// ModelLimitEntry is a learned or configured per-model capability/limit.
+type ModelLimitEntry struct {
+	MaxOutputTokens int       `json:"max_output_tokens,omitempty"`
+	ContextWindow   int       `json:"context_window,omitempty"`
+	SupportsTools   *bool     `json:"supports_tools,omitempty"`
+	Source          string    `json:"source,omitempty"` // e.g. "learned_400"
+	UpdatedAt       time.Time `json:"updated_at,omitempty"`
+}
+
+// ModelLimitsStore persists per-provider/model token limits and capabilities
+// learned from provider error responses (or set explicitly). Platform-scoped.
+type ModelLimitsStore interface {
+	// Get returns the learned limits for provider/model, or nil if none.
+	Get(ctx context.Context, provider, model string) (*ModelLimitEntry, error)
+
+	// UpsertMaxOutput stores maxOutputTokens for provider/model.
+	// Only decreases an existing value (or sets if missing).
+	UpsertMaxOutput(ctx context.Context, provider, model string, max int, source string) error
+
+	// UpsertSupportsTools stores whether the model supports function calling.
+	// Only persists supports == false (we only learn the negative from errors).
+	UpsertSupportsTools(ctx context.Context, provider, model string, supports bool, source string) error
+}
+
+// ModelLimitsKey builds the composite map key used in platform_settings.
+func ModelLimitsKey(provider, model string) string {
+	return fmt.Sprintf("%s/%s", provider, model)
+}

--- a/web/src/components/StudioChat.tsx
+++ b/web/src/components/StudioChat.tsx
@@ -8,7 +8,7 @@ import type { ChatSession, AttachmentPayload, SessionModelStatus } from '../api/
 import { startFleetSession, connectFleetStream, sendFleetMessage, stopFleetSession, fetchFleetSessions } from '../api/fleetChat'
 import type { FleetSession } from '../api/fleetChat'
 import HomePage from './HomePage'
-import type { FleetMessageItem, ChatMsg, FleetInfo, FleetStateInfo, DeferredPrompt, FleetExecutionMessage, FleetEvent, AgentMessage, ToolCallMessage, ToolResultMessage, BrowserHandoffMessage, SubTaskExecutionMessage, SubTaskEvent, SubTaskInfo, PlanMessage, PlanStepInfo, SessionArtifact, ArtifactMessage, AppPreviewMessage, AppSavedMessage, DistillPreviewMessage, DistillSavedMessage, TutorialBlueprintPreviewMessage, TutorialBlueprintApprovedMessage, TutorialSceneSlideshowMessage, UserMessage, AttachmentInfo, NetworkDenialMessage } from './chat/chatTypes'
+import type { FleetMessageItem, ChatMsg, FleetInfo, FleetStateInfo, DeferredPrompt, FleetExecutionMessage, FleetEvent, AgentMessage, ToolCallMessage, ToolResultMessage, BrowserHandoffMessage, SubTaskExecutionMessage, SubTaskEvent, SubTaskInfo, PlanMessage, PlanStepInfo, SessionArtifact, ArtifactMessage, AppPreviewMessage, AppSavedMessage, DistillPreviewMessage, DistillSavedMessage, TutorialBlueprintPreviewMessage, TutorialBlueprintApprovedMessage, TutorialSceneSlideshowMessage, UserMessage, AttachmentInfo, NetworkDenialMessage, ImageMessage } from './chat/chatTypes'
 import { getAgentColor } from './chat/chatTypes'
 import FleetStartDialog from './chat/FleetStartDialog'
 import FleetTemplatePicker from './chat/FleetTemplatePicker'
@@ -830,6 +830,9 @@ export default function StudioChat({ theme, initialSessionId, pendingChatMessage
           }
           if (m.type === 'flow_output') {
             return { type: 'agent', content: m.content || '' } as AgentMessage
+          }
+          if (m.type === 'image' && m.data && m.mimeType) {
+            return { type: 'image', data: m.data, mimeType: m.mimeType } as ImageMessage
           }
           if (m.type === 'plan') {
             return { type: 'plan', goal: m.goal || '', steps: m.steps ?? [] } as PlanMessage


### PR DESCRIPTION
## Summary
- Recursively sanitize Vertex/Gemini tool schemas and stop treating every HTTP 400 as context overflow.
- Learn per-model `maxOutputTokens` and “no function calling” from provider 400 bodies (persist in platform `model_limits`, retry once).
- Parse model `inlineData` images into Studio SSE/history and deliver them on Slack, Telegram, and Email.

## Test plan
- [ ] `go test ./pkg/provider/vertex/ ./pkg/provider/sap/ ./pkg/provider/llmerror/ ./pkg/api/ ./pkg/agent/ ./pkg/channels/ ./pkg/channels/email/`
- [ ] Chat with SAP AI Core Gemini text model: tools work; nested schemas no longer 400.
- [ ] Chat with `gemini-*-image` (or similar): first turn learns maxOutputTokens / no-tools and succeeds; image generation shows in Studio and reloads from history.
- [ ] Channel smoke: image-only or image+text turn reaches Slack/Telegram; Email includes image attachment.