### PR TITLE
Make harness App previews fill available vertical space

### DIFF
--- a/web/src/components/chat/AppPreview.tsx
+++ b/web/src/components/chat/AppPreview.tsx
@@ -16,13 +16,15 @@ interface AppPreviewProps {
   appName?: string
   /** App identifier for persistent state (appName takes precedence, falls back to this) */
   stateId?: string
+  /** Stretch the iframe to fill the parent instead of auto-sizing to content (capped by maxHeight). */
+  fillHeight?: boolean
 }
 
 function detectTheme(): 'dark' | 'light' {
   return document.documentElement.classList.contains('dark') ? 'dark' : 'light'
 }
 
-export default function AppPreview({ code, maxHeight = 500, appName = '', stateId = '' }: AppPreviewProps) {
+export default function AppPreview({ code, maxHeight = 500, appName = '', stateId = '', fillHeight = false }: AppPreviewProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [height, setHeight] = useState(200)
   const [error, setError] = useState<string | null>(null)
@@ -79,7 +81,7 @@ export default function AppPreview({ code, maxHeight = 500, appName = '', stateI
           break
         case 'render_success':
           setError(null)
-          if (msg.height && typeof msg.height === 'number') {
+          if (!fillHeight && msg.height && typeof msg.height === 'number') {
             setHeight(Math.min(msg.height + 2, maxHeight))
           }
           break
@@ -300,7 +302,7 @@ export default function AppPreview({ code, maxHeight = 500, appName = '', stateI
 
     window.addEventListener('message', handleMessage)
     return () => window.removeEventListener('message', handleMessage)
-  }, [maxHeight, sendCode, sendTheme, sendToIframe, appName, stateId])
+  }, [maxHeight, fillHeight, sendCode, sendTheme, sendToIframe, appName, stateId])
 
   // Watch for theme changes on the document element and forward to sandbox
   useEffect(() => {
@@ -321,19 +323,19 @@ export default function AppPreview({ code, maxHeight = 500, appName = '', stateI
   }, [code, ready, sendCode])
 
   return (
-    <div className="relative w-full">
+    <div className={fillHeight ? 'relative w-full h-full min-h-0' : 'relative w-full'}>
       <iframe
         ref={iframeRef}
         src={SANDBOX_URL}
         sandbox="allow-scripts allow-forms"
         style={{
           width: '100%',
-          height: `${height}px`,
+          height: fillHeight ? '100%' : `${height}px`,
           border: 'none',
           borderRadius: '8px',
           overflow: 'hidden',
           background: 'var(--bg-primary)',
-          transition: 'height 0.2s ease',
+          transition: fillHeight ? undefined : 'height 0.2s ease',
         }}
         title="App Preview"
       />

--- a/web/src/components/chat/AppPreviewCard.tsx
+++ b/web/src/components/chat/AppPreviewCard.tsx
@@ -16,6 +16,8 @@ interface AppPreviewCardProps {
   isActive?: boolean
   /** Session ID for scoping persistent state of unsaved in-chat apps */
   sessionId?: string | null
+  /** Fill parent height (harness panel) instead of a 500px content-sized preview. */
+  fillHeight?: boolean
 }
 
 export default function AppPreviewCard({
@@ -26,6 +28,7 @@ export default function AppPreviewCard({
   onSave,
   isActive = false,
   sessionId,
+  fillHeight = false,
 }: AppPreviewCardProps) {
   const [showCode, setShowCode] = useState(false)
   const [isFullscreen, setIsFullscreen] = useState(false)
@@ -86,9 +89,17 @@ export default function AppPreviewCard({
     navigator.clipboard.writeText(displayedData.code)
   }, [displayedData.code])
 
-  const renderCard = (fullscreen: boolean) => (
+  const renderCard = (fullscreen: boolean) => {
+    const stretchPreview = fullscreen || fillHeight
+    return (
     <div
-      className={fullscreen ? 'flex flex-col h-full' : 'my-3 rounded-xl overflow-hidden w-full'}
+      className={
+        fullscreen
+          ? 'flex flex-col h-full'
+          : fillHeight
+            ? 'flex flex-col h-full min-h-0 rounded-xl overflow-hidden w-full'
+            : 'my-3 rounded-xl overflow-hidden w-full'
+      }
       style={fullscreen ? {} : {
         border: `1px solid ${isActive ? 'var(--accent)' : 'var(--border-color)'}`,
         background: 'var(--bg-secondary)',
@@ -262,7 +273,7 @@ export default function AppPreviewCard({
           <pre
             className="px-4 pb-3 text-[11px] overflow-x-auto font-mono leading-relaxed"
             style={{
-              maxHeight: fullscreen ? '40vh' : '200px',
+              maxHeight: fullscreen ? '40vh' : fillHeight ? '25vh' : '200px',
               overflowY: 'auto',
               color: 'var(--text-secondary)',
             }}
@@ -273,15 +284,17 @@ export default function AppPreviewCard({
       )}
 
       {/* Preview */}
-      <div className={fullscreen ? 'flex-1 overflow-auto p-2' : 'px-3 py-2'}>
+      <div className={stretchPreview ? 'flex-1 min-h-0 overflow-hidden p-2' : 'px-3 py-2'}>
         <AppPreview
           code={displayedData.code}
-          maxHeight={fullscreen ? 9999 : 500}
+          maxHeight={stretchPreview ? 9999 : 500}
+          fillHeight={stretchPreview}
           stateId={sessionId ? `session:${sessionId}:${displayedData.title || displayedData.appId || ''}` : (displayedData.title || displayedData.appId || '')}
         />
       </div>
     </div>
-  )
+    )
+  }
 
   return (
     <>

--- a/web/src/components/chat/HarnessPanel.tsx
+++ b/web/src/components/chat/HarnessPanel.tsx
@@ -169,7 +169,11 @@ export default function HarnessPanel({
     }
   })()
 
-  const fillBody = focus.kind === 'report' || focus.kind === 'video' || focus.kind === 'browser_handoff'
+  const fillBody =
+    focus.kind === 'report' ||
+    focus.kind === 'video' ||
+    focus.kind === 'browser_handoff' ||
+    focus.kind === 'app'
 
   return (
     <div
@@ -254,15 +258,18 @@ export default function HarnessPanel({
           const data = appVersions[Math.min(appVersionIndex, appVersions.length - 1)] as AppPreviewMessage
           const isActive = activeAppId != null && (data.appId === activeAppId || (!data.appId && data.title === activeAppId))
           return (
-            <AppPreviewCard
-              data={data}
-              versions={appVersions.length > 1 ? appVersions : undefined}
-              versionIndex={appVersionIndex}
-              onNavigateVersion={setAppVersionIndex}
-              isActive={isActive}
-              onSave={isActive && onAppSave ? onAppSave : undefined}
-              sessionId={sessionId}
-            />
+            <div className="flex-1 min-h-0 h-full">
+              <AppPreviewCard
+                data={data}
+                versions={appVersions.length > 1 ? appVersions : undefined}
+                versionIndex={appVersionIndex}
+                onNavigateVersion={setAppVersionIndex}
+                isActive={isActive}
+                onSave={isActive && onAppSave ? onAppSave : undefined}
+                sessionId={sessionId}
+                fillHeight
+              />
+            </div>
           )
         })()}
 


### PR DESCRIPTION
## Summary
- Add `fillHeight` to `AppPreview` / `AppPreviewCard` so the iframe stretches to the parent instead of capping at 500px
- Enable that path in the harness panel for app focus (same layout approach as reports)

## Test plan
- [x] Open Studio Chat, generate an app so the harness panel opens
- [x] Confirm the app preview uses the full panel height (no large empty area under a short 500px frame)
- [x] Toggle code view and confirm the preview still keeps most of the remaining height
- [x] Fullscreen app preview still works
- [x] Compact stream placeholder for apps is unchanged